### PR TITLE
Adds no-op create processing

### DIFF
--- a/service/resource/configmap/create.go
+++ b/service/resource/configmap/create.go
@@ -4,10 +4,14 @@ import (
 	"context"
 )
 
+// GetCreateState is a no-op.
+// The controller is given a configuration, which it then controls,
+// we do not create a prometheus configuration from scratch.
 func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
 	return nil, nil
 }
 
+// ProcessCreateState is a no-op.
 func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
 	return nil
 }

--- a/service/resource/configmap/create_test.go
+++ b/service/resource/configmap/create_test.go
@@ -1,1 +1,59 @@
 package configmap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+)
+
+// Test_Resource_ConfigMap_GetCreateState tests the GetCreateState method.
+func Test_Resource_ConfigMap_GetCreateState(t *testing.T) {
+	fakeK8sClient := fake.NewSimpleClientset()
+
+	resourceConfig := DefaultConfig()
+
+	resourceConfig.K8sClient = fakeK8sClient
+	resourceConfig.Logger = microloggertest.New()
+
+	resourceConfig.ConfigMapName = "prometheus"
+	resourceConfig.ConfigMapNamespace = "monitoring"
+
+	resource, err := New(resourceConfig)
+	if err != nil {
+		t.Fatalf("error returned creating resource: %s\n", err)
+	}
+
+	createState, err := resource.GetCreateState(context.TODO(), v1.Service{}, v1.ConfigMap{}, v1.ConfigMap{})
+	if err != nil {
+		t.Fatalf("error returned getting create state: %s\n", err)
+	}
+
+	if createState != nil {
+		t.Fatalf("create state should be nil, was: %#v", createState)
+	}
+}
+
+// Test_Resource_ConfigMap_ProcessCreateState tests the ProcessCreateState method.
+func Test_Resource_ConfigMap_ProcessCreateState(t *testing.T) {
+	fakeK8sClient := fake.NewSimpleClientset()
+
+	resourceConfig := DefaultConfig()
+
+	resourceConfig.K8sClient = fakeK8sClient
+	resourceConfig.Logger = microloggertest.New()
+
+	resourceConfig.ConfigMapName = "prometheus"
+	resourceConfig.ConfigMapNamespace = "monitoring"
+
+	resource, err := New(resourceConfig)
+	if err != nil {
+		t.Fatalf("error returned creating resource: %s\n", err)
+	}
+
+	if err := resource.ProcessCreateState(context.TODO(), v1.Service{}, v1.ConfigMap{}); err != nil {
+		t.Fatalf("error returned processing create state: %s\n", err)
+	}
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

As the prometheus configuration can vary between installations, we need to pass it to the controller, which then manages it - the controller cannot create it. So, comments describing such, and a few tests to make sure.