### PR TITLE
Adds support for computing desired state

### DIFF
--- a/flag/service/resource/configmap/configmap.go
+++ b/flag/service/resource/configmap/configmap.go
@@ -1,6 +1,7 @@
 package configmap
 
 type ConfigMap struct {
+	Key       string
 	Name      string
 	Namespace string
 }

--- a/main.go
+++ b/main.go
@@ -145,6 +145,7 @@ func mainWithError() error {
 
 	daemonCommand.PersistentFlags().Int(f.Service.Resource.Retries, 3, "Number of times to retry resources.")
 
+	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Key, "prometheus.yml", "Key in configmap under which prometheus configuration is held.")
 	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Name, "prometheus", "Name of prometheus configmap to control.")
 	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Namespace, "monitoring", "Namespace of prometheus configmap to control.")
 

--- a/service/resource/configmap/configmap.go
+++ b/service/resource/configmap/configmap.go
@@ -16,6 +16,8 @@ type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
+	// ConfigMapKey is the key in the configmap under which the prometheus configuration is held.
+	ConfigMapKey       string
 	ConfigMapName      string
 	ConfigMapNamespace string
 }
@@ -25,6 +27,7 @@ func DefaultConfig() Config {
 		K8sClient: nil,
 		Logger:    nil,
 
+		ConfigMapKey:       "",
 		ConfigMapName:      "",
 		ConfigMapNamespace: "",
 	}
@@ -34,6 +37,7 @@ type Resource struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
+	configMapKey       string
 	configMapName      string
 	configMapNamespace string
 }
@@ -46,6 +50,9 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 
+	if config.ConfigMapKey == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ConfigMapKey must not be empty")
+	}
 	if config.ConfigMapName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.ConfigMapName must not be empty")
 	}
@@ -57,6 +64,7 @@ func New(config Config) (*Resource, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
+		configMapKey:       config.ConfigMapKey,
 		configMapName:      config.ConfigMapName,
 		configMapNamespace: config.ConfigMapNamespace,
 	}

--- a/service/resource/configmap/create_test.go
+++ b/service/resource/configmap/create_test.go
@@ -18,6 +18,7 @@ func Test_Resource_ConfigMap_GetCreateState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"
 
@@ -45,6 +46,7 @@ func Test_Resource_ConfigMap_ProcessCreateState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"
 

--- a/service/resource/configmap/current_test.go
+++ b/service/resource/configmap/current_test.go
@@ -65,6 +65,7 @@ func Test_Resource_ConfigMap_GetCurrentState(t *testing.T) {
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
 
+		resourceConfig.ConfigMapKey = "prometheus.yml"
 		resourceConfig.ConfigMapName = configMapName
 		resourceConfig.ConfigMapNamespace = configMapNamespace
 

--- a/service/resource/configmap/delete_test.go
+++ b/service/resource/configmap/delete_test.go
@@ -18,6 +18,7 @@ func Test_Resource_ConfigMap_GetDeleteState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"
 
@@ -45,6 +46,7 @@ func Test_Resource_ConfigMap_ProcessDeleteState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"
 

--- a/service/resource/configmap/desired.go
+++ b/service/resource/configmap/desired.go
@@ -2,8 +2,58 @@ package configmap
 
 import (
 	"context"
+
+	"github.com/prometheus/prometheus/config"
+	"gopkg.in/yaml.v2"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
-	return nil, nil
+	configMap, err := r.k8sClient.CoreV1().ConfigMaps(r.configMapNamespace).Get(
+		r.configMapName, metav1.GetOptions{},
+	)
+	if errors.IsNotFound(err) {
+		return nil, microerror.Maskf(configMapNotFoundError, "%s/%s", r.configMapNamespace, r.configMapName)
+	} else if err != nil {
+		return nil, microerror.Maskf(err, "an error occurred fetching the configmap %s/%s", r.configMapNamespace, r.configMapName)
+	}
+
+	configMapData, ok := configMap.Data[r.configMapKey]
+	if !ok {
+		return nil, microerror.Maskf(configMapKeyNotFoundError, "%s/%s - %s", r.configMapNamespace, r.configMapName, r.configMapKey)
+	}
+
+	prometheusConfig, err := config.Load(configMapData)
+	if err != nil {
+		return nil, microerror.Maskf(invalidConfigMapError, err.Error())
+	}
+
+	services, err := r.k8sClient.CoreV1().Services("").List(metav1.ListOptions{})
+	if err != nil {
+		return nil, microerror.Maskf(err, "an error occurred listing all services")
+	}
+
+	scrapeConfigs, err := prometheus.GetScrapeConfigs(services.Items)
+	if err != nil {
+		return nil, microerror.Maskf(err, "an error occurred creating scrape configs")
+	}
+
+	newPrometheusConfig, err := prometheus.ConfigMerge(*prometheusConfig, scrapeConfigs)
+	if err != nil {
+		return nil, microerror.Maskf(err, "an error occurred merging prometheus config")
+	}
+
+	newConfigMapData, err := yaml.Marshal(newPrometheusConfig)
+	if err != nil {
+		return nil, microerror.Maskf(err, "an error occurred marshaling yaml")
+	}
+
+	configMap.Data[r.configMapKey] = string(newConfigMapData)
+
+	return configMap, nil
 }

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -1,1 +1,329 @@
 package configmap
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/config"
+	"gopkg.in/yaml.v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
+)
+
+func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
+	configMapKey := "prometheus.yml"
+	configMapName := "prometheus"
+	configMapNamespace := "monitoring"
+
+	tests := []struct {
+		setUpPrometheusConfiguration *config.Config
+		setUpConfigMap               *v1.ConfigMap
+		setUpServices                []*v1.Service
+
+		expectedPrometheusConfiguration *config.Config
+		expectedErrorHandler            func(error) bool
+	}{
+		// Test that if the configmap does not exist,
+		// an error is returned.
+		{
+			setUpPrometheusConfiguration: nil,
+			setUpConfigMap:               nil,
+			setUpServices:                nil,
+
+			expectedPrometheusConfiguration: nil,
+			expectedErrorHandler:            IsConfigMapNotFound,
+		},
+
+		// Test that if the configmap does exist, but is empty,
+		// an error is returned.
+		{
+			setUpPrometheusConfiguration: nil,
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+				Data: map[string]string{},
+			},
+			setUpServices: nil,
+
+			expectedPrometheusConfiguration: nil,
+			expectedErrorHandler:            IsConfigMapKeyNotFound,
+		},
+
+		// Test that if the configmap does exist, with an invalid config,
+		// an error is returned.
+		{
+			setUpPrometheusConfiguration: nil,
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+				Data: map[string]string{
+					configMapKey: "lkjwhndwlkjndlkwdnwdn", // Intentionally garbage.
+				},
+			},
+			setUpServices: nil,
+
+			expectedPrometheusConfiguration: nil,
+			expectedErrorHandler:            IsInvalidConfigMap,
+		},
+
+		// Test that if the configmap does exist, with a valid config,
+		// and no services exist,
+		// the configmap is returned without modifications.
+		// Note - the returned config is marshalled, so some defaults appear.
+		{
+			setUpPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "kubernetes-nodes",
+					},
+				},
+			},
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			},
+			setUpServices: nil,
+
+			expectedPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval:     model.Duration(1 * time.Minute),
+					ScrapeTimeout:      model.Duration(10 * time.Second),
+					EvaluationInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName:        "kubernetes-nodes",
+						ScrapeInterval: model.Duration(1 * time.Minute),
+						ScrapeTimeout:  model.Duration(10 * time.Second),
+						MetricsPath:    "/metrics",
+						Scheme:         "http",
+					},
+				},
+			},
+			expectedErrorHandler: nil,
+		},
+
+		// Test that if the configmap does exist, with a valid config,
+		// and a non-annotated service exists,
+		// the configmap is returned without modification.
+		{
+			setUpPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "kubernetes-nodes",
+					},
+				},
+			},
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			},
+			setUpServices: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "default",
+					},
+				},
+			},
+
+			expectedPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval:     model.Duration(1 * time.Minute),
+					ScrapeTimeout:      model.Duration(10 * time.Second),
+					EvaluationInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName:        "kubernetes-nodes",
+						ScrapeInterval: model.Duration(1 * time.Minute),
+						ScrapeTimeout:  model.Duration(10 * time.Second),
+						MetricsPath:    "/metrics",
+						Scheme:         "http",
+					},
+				},
+			},
+			expectedErrorHandler: nil,
+		},
+
+		// Test that if the configmap does exist, with a valid config,
+		// and am annotated service exists,
+		// the configmap is returned with the new service.
+		{
+			setUpPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "kubernetes-nodes",
+					},
+				},
+			},
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			},
+			setUpServices: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "apiserver",
+						Namespace: "xa5ly",
+						Annotations: map[string]string{
+							prometheus.ClusterAnnotation:     "xa5ly",
+							prometheus.CertificateAnnotation: "default/xa5ly-prometheus",
+						},
+					},
+				},
+			},
+
+			expectedPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval:     model.Duration(1 * time.Minute),
+					ScrapeTimeout:      model.Duration(10 * time.Second),
+					EvaluationInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName:        "kubernetes-nodes",
+						ScrapeInterval: model.Duration(1 * time.Minute),
+						ScrapeTimeout:  model.Duration(10 * time.Second),
+						MetricsPath:    "/metrics",
+						Scheme:         "http",
+					},
+					{
+						JobName: "xa5ly",
+						Scheme:  "https",
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly/ca.pem",
+								CertFile:           "/certs/xa5ly/crt.pem",
+								KeyFile:            "/certs/xa5ly/key.pem",
+								InsecureSkipVerify: false,
+							},
+						},
+						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+							StaticConfigs: []*config.TargetGroup{
+								{
+									Targets: []model.LabelSet{
+										model.LabelSet{"apiserver.xa5ly": ""},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedErrorHandler: nil,
+		},
+	}
+
+	for index, test := range tests {
+		fakeK8sClient := fake.NewSimpleClientset()
+
+		resourceConfig := DefaultConfig()
+
+		resourceConfig.K8sClient = fakeK8sClient
+		resourceConfig.Logger = microloggertest.New()
+
+		resourceConfig.ConfigMapKey = configMapKey
+		resourceConfig.ConfigMapName = configMapName
+		resourceConfig.ConfigMapNamespace = configMapNamespace
+
+		resource, err := New(resourceConfig)
+		if err != nil {
+			t.Fatalf("%d: error returned creating resource: %s\n", index, err)
+		}
+
+		if test.setUpPrometheusConfiguration != nil {
+			prometheusConfig, err := yaml.Marshal(test.setUpPrometheusConfiguration)
+			if err != nil {
+				t.Fatalf("%d: error returned marshaling prometheus configuration: %s\n", index, err)
+			}
+
+			if test.setUpConfigMap.Data == nil {
+				test.setUpConfigMap.Data = map[string]string{}
+			}
+			test.setUpConfigMap.Data[configMapKey] = string(prometheusConfig)
+		}
+
+		if test.setUpConfigMap != nil {
+			if _, err := fakeK8sClient.CoreV1().ConfigMaps(configMapNamespace).Create(test.setUpConfigMap); err != nil {
+				t.Fatalf("%d: error returned setting up configmap: %s\n", index, err)
+			}
+		}
+
+		for _, service := range test.setUpServices {
+			if _, err := fakeK8sClient.CoreV1().Services(service.Namespace).Create(service); err != nil {
+				t.Fatalf("%d: error returned setting up service: %s\n", index, err)
+			}
+		}
+
+		desiredState, err := resource.GetDesiredState(context.TODO(), v1.Service{})
+
+		if err != nil && test.expectedErrorHandler == nil {
+			t.Fatalf("%d: unexpected error returned getting desired state: %s\n", index, err)
+		}
+		if err != nil && !test.expectedErrorHandler(err) {
+			t.Fatalf("%d: incorrect error returned getting desired state: %s\n", index, err)
+		}
+		if err == nil && test.expectedErrorHandler != nil {
+			t.Fatalf("%d: expected error not returned getting desired state\n", index)
+		}
+
+		if test.expectedPrometheusConfiguration == nil && desiredState != nil {
+			t.Fatalf("%d: unexpected configmap returned getting desired state: %s\n", index, spew.Sdump(desiredState))
+		}
+
+		if test.expectedPrometheusConfiguration != nil {
+			desiredStateConfigMap, ok := desiredState.(*v1.ConfigMap)
+			if !ok {
+				t.Fatalf("%d: could not cast desired state to configmap: %s\n", index, spew.Sdump(desiredState))
+			}
+
+			expectedPrometheusConfigurationBytes, err := yaml.Marshal(test.expectedPrometheusConfiguration)
+			if err != nil {
+				t.Fatalf("%d: could not marshal expected prometheus configuration: %s\n", index, err)
+			}
+			expectedPrometheusConfiguration := string(expectedPrometheusConfigurationBytes)
+
+			returnedPrometheusConfiguration, ok := desiredStateConfigMap.Data[configMapKey]
+			if !ok {
+				t.Fatalf("%d: configuration key not found in desired state configmap: %s\n", index, spew.Sdump(desiredState))
+			}
+
+			if expectedPrometheusConfiguration != returnedPrometheusConfiguration {
+				t.Fatalf(
+					"%d: expected configmap does not match returned desired state.\nexpected:\n%s\nreturned:\n%s\n",
+					index,
+					expectedPrometheusConfiguration,
+					returnedPrometheusConfiguration,
+				)
+			}
+		}
+	}
+}

--- a/service/resource/configmap/error.go
+++ b/service/resource/configmap/error.go
@@ -10,3 +10,24 @@ var invalidConfigError = microerror.New("invalid config")
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var configMapNotFoundError = microerror.New("configmap not found")
+
+// IsConfigMapNotFound asserts configMapNotFoundError.
+func IsConfigMapNotFound(err error) bool {
+	return microerror.Cause(err) == configMapNotFoundError
+}
+
+var configMapKeyNotFoundError = microerror.New("configmap key not found")
+
+// IsConfigMapKeyNotFound asserts configMapKeyNotFoundError.
+func IsConfigMapKeyNotFound(err error) bool {
+	return microerror.Cause(err) == configMapKeyNotFoundError
+}
+
+var invalidConfigMapError = microerror.New("invalid config map")
+
+// IsInvalidConfigMap asserts invalidConfigMapError.
+func IsInvalidConfigMap(err error) bool {
+	return microerror.Cause(err) == invalidConfigMapError
+}

--- a/service/service.go
+++ b/service/service.go
@@ -103,6 +103,7 @@ func New(config Config) (*Service, error) {
 		configMapConfig.K8sClient = newK8sClient
 		configMapConfig.Logger = config.Logger
 
+		configMapConfig.ConfigMapKey = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Key)
 		configMapConfig.ConfigMapName = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Name)
 		configMapConfig.ConfigMapNamespace = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Namespace)
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

We flesh out `GetDesiredState` further here, with basic support for updating the prometheus configuration based on annotated services.

`ConfigMerge` doesn't currently support removing scrape configs for services that are no longer present. Planning on adding support for this next, and also adding a further test for it as part of the `GetDesiredState` tests, to reduce scope.