### PR TITLE
Adds boilerplate for certificate resource

### DIFF
--- a/service/resource/certificate/certificate.go
+++ b/service/resource/certificate/certificate.go
@@ -1,0 +1,31 @@
+package certificate
+
+import (
+	"github.com/giantswarm/operatorkit/framework"
+)
+
+const (
+	Name = "certificate"
+)
+
+type Config struct{}
+
+func DefaultConfig() Config {
+	return Config{}
+}
+
+type Resource struct{}
+
+func New(config Config) (*Resource, error) {
+	resource := &Resource{}
+
+	return resource, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) Underlying() framework.Resource {
+	return r
+}

--- a/service/resource/certificate/certificate_test.go
+++ b/service/resource/certificate/certificate_test.go
@@ -1,0 +1,1 @@
+package certificate

--- a/service/resource/certificate/create.go
+++ b/service/resource/certificate/create.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"context"
+)
+
+func (r *Resource) GetCreateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (r *Resource) ProcessCreateState(ctx context.Context, obj, createState interface{}) error {
+	return nil
+}

--- a/service/resource/certificate/create_test.go
+++ b/service/resource/certificate/create_test.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"testing"
+)
+
+// Test_Resource_Certificate_GetCreateState tests the GetCreateState method.
+func Test_Resource_Certificate_GetCreateState(t *testing.T) {
+}
+
+// Test_Resource_Certificate_ProcessCreateState tests the ProcessCreateState method.
+func Test_Resource_Certificate_ProcessCreateState(t *testing.T) {
+}

--- a/service/resource/certificate/current.go
+++ b/service/resource/certificate/current.go
@@ -1,0 +1,9 @@
+package certificate
+
+import (
+	"context"
+)
+
+func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/resource/certificate/current_test.go
+++ b/service/resource/certificate/current_test.go
@@ -1,0 +1,9 @@
+package certificate
+
+import (
+	"testing"
+)
+
+// Test_Resource_Certificate_GetCurrentState tests the GetCurrentState method.
+func Test_Resource_Certificate_GetCurrentState(t *testing.T) {
+}

--- a/service/resource/certificate/delete.go
+++ b/service/resource/certificate/delete.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"context"
+)
+
+func (r *Resource) GetDeleteState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, error) {
+	return nil, nil
+}
+
+func (r *Resource) ProcessDeleteState(ctx context.Context, obj, deleteState interface{}) error {
+	return nil
+}

--- a/service/resource/certificate/delete_test.go
+++ b/service/resource/certificate/delete_test.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"testing"
+)
+
+// Test_Resource_Certificate_GetDeleteState tests the GetDeleteState method.
+func Test_Resource_Certificate_GetDeleteState(t *testing.T) {
+}
+
+// Test_Resource_Certificate_ProcessDeleteState tests the ProcessDeleteState method.
+func Test_Resource_Certificate_ProcessDeleteState(t *testing.T) {
+}

--- a/service/resource/certificate/desired.go
+++ b/service/resource/certificate/desired.go
@@ -1,0 +1,9 @@
+package certificate
+
+import (
+	"context"
+)
+
+func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
+	return nil, nil
+}

--- a/service/resource/certificate/desired_test.go
+++ b/service/resource/certificate/desired_test.go
@@ -1,0 +1,9 @@
+package certificate
+
+import (
+	"testing"
+)
+
+// Test_Resource_Certificate_GetDesiredState tests the GetDesiredState method.
+func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
+}

--- a/service/resource/certificate/error.go
+++ b/service/resource/certificate/error.go
@@ -1,0 +1,1 @@
+package certificate

--- a/service/resource/certificate/update.go
+++ b/service/resource/certificate/update.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"context"
+)
+
+func (r *Resource) GetUpdateState(ctx context.Context, obj, currentState, desiredState interface{}) (interface{}, interface{}, interface{}, error) {
+	return nil, nil, nil, nil
+}
+
+func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState interface{}) error {
+	return nil
+}

--- a/service/resource/certificate/update_test.go
+++ b/service/resource/certificate/update_test.go
@@ -1,0 +1,13 @@
+package certificate
+
+import (
+	"testing"
+)
+
+// Test_Resource_Certificate_GetUpdateState tests the GetUpdateState method.
+func Test_Resource_Certificate_GetUpdateState(t *testing.T) {
+}
+
+// Test_Resource_Certificate_ProcessUpdateState tests the ProcessUpdateState method.
+func Test_Resource_Certificate_ProcessUpdateState(t *testing.T) {
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR adds the `operatorkit` framework boilerplate. Following PRs will fill in the stubs.