### PR TITLE
Makes certificate path configurable

### DIFF
--- a/flag/service/resource/resource.go
+++ b/flag/service/resource/resource.go
@@ -5,6 +5,7 @@ import (
 )
 
 type Resource struct {
-	ConfigMap configmap.ConfigMap
-	Retries   string
+	CertificateDirectory string
+	ConfigMap            configmap.ConfigMap
+	Retries              string
 }

--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func mainWithError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 
+	daemonCommand.PersistentFlags().String(f.Service.Resource.CertificateDirectory, "/certs", "Directory in which to store certificates.")
 	daemonCommand.PersistentFlags().Int(f.Service.Resource.Retries, 3, "Number of times to retry resources.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Key, "prometheus.yml", "Key in configmap under which prometheus configuration is held.")

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -2,16 +2,21 @@ package key
 
 import (
 	"fmt"
+	"path"
 )
 
-func CAPath(groupName string) string {
-	return fmt.Sprintf("/certs/%s/ca.pem", groupName)
+func certPath(certificateDirectory, groupName, suffix string) string {
+	return path.Join(certificateDirectory, fmt.Sprintf("%s-%s.pem", groupName, suffix))
 }
 
-func CrtPath(groupName string) string {
-	return fmt.Sprintf("/certs/%s/crt.pem", groupName)
+func CAPath(certificateDirectory, groupName string) string {
+	return certPath(certificateDirectory, groupName, "ca")
 }
 
-func KeyPath(groupName string) string {
-	return fmt.Sprintf("/certs/%s/key.pem", groupName)
+func CrtPath(certificateDirectory, groupName string) string {
+	return certPath(certificateDirectory, groupName, "crt")
+}
+
+func KeyPath(certificateDirectory, groupName string) string {
+	return certPath(certificateDirectory, groupName, "key")
 }

--- a/service/key/key_test.go
+++ b/service/key/key_test.go
@@ -10,21 +10,33 @@ import (
 // Test_Key_CAPath tests the CAPath function.
 func Test_Key_CAPath(t *testing.T) {
 	tests := []struct {
-		groupName    string
+		certificateDirectory string
+		groupName            string
+
 		expectedPath string
 	}{
 		{
-			groupName:    "xa5ly",
-			expectedPath: "/certs/xa5ly/ca.pem",
+			certificateDirectory: "/certs",
+			groupName:            "xa5ly",
+
+			expectedPath: "/certs/xa5ly-ca.pem",
 		},
 		{
-			groupName:    "fah0a",
-			expectedPath: "/certs/fah0a/ca.pem",
+			certificateDirectory: "/certs",
+			groupName:            "fah0a",
+
+			expectedPath: "/certs/fah0a-ca.pem",
+		},
+		{
+			certificateDirectory: "/certificates",
+			groupName:            "fah0a",
+
+			expectedPath: "/certificates/fah0a-ca.pem",
 		},
 	}
 
 	for index, test := range tests {
-		path := CAPath(test.groupName)
+		path := CAPath(test.certificateDirectory, test.groupName)
 
 		if !reflect.DeepEqual(test.expectedPath, path) {
 			t.Fatalf(
@@ -40,21 +52,33 @@ func Test_Key_CAPath(t *testing.T) {
 // Test_Key_CrtPath tests the CrtPath function.
 func Test_Key_CrtPath(t *testing.T) {
 	tests := []struct {
-		groupName    string
+		certificateDirectory string
+		groupName            string
+
 		expectedPath string
 	}{
 		{
-			groupName:    "xa5ly",
-			expectedPath: "/certs/xa5ly/crt.pem",
+			certificateDirectory: "/certs",
+			groupName:            "xa5ly",
+
+			expectedPath: "/certs/xa5ly-crt.pem",
 		},
 		{
-			groupName:    "fah0a",
-			expectedPath: "/certs/fah0a/crt.pem",
+			certificateDirectory: "/certs",
+			groupName:            "fah0a",
+
+			expectedPath: "/certs/fah0a-crt.pem",
+		},
+		{
+			certificateDirectory: "/certificates",
+			groupName:            "fah0a",
+
+			expectedPath: "/certificates/fah0a-crt.pem",
 		},
 	}
 
 	for index, test := range tests {
-		path := CrtPath(test.groupName)
+		path := CrtPath(test.certificateDirectory, test.groupName)
 
 		if !reflect.DeepEqual(test.expectedPath, path) {
 			t.Fatalf(
@@ -70,21 +94,33 @@ func Test_Key_CrtPath(t *testing.T) {
 // Test_Key_KeyPath tests the KeyPath function.
 func Test_Key_KeyPath(t *testing.T) {
 	tests := []struct {
-		groupName    string
+		certificateDirectory string
+		groupName            string
+
 		expectedPath string
 	}{
 		{
-			groupName:    "xa5ly",
-			expectedPath: "/certs/xa5ly/key.pem",
+			certificateDirectory: "/certs",
+			groupName:            "xa5ly",
+
+			expectedPath: "/certs/xa5ly-key.pem",
 		},
 		{
-			groupName:    "fah0a",
-			expectedPath: "/certs/fah0a/key.pem",
+			certificateDirectory: "/certs",
+			groupName:            "fah0a",
+
+			expectedPath: "/certs/fah0a-key.pem",
+		},
+		{
+			certificateDirectory: "/certificates",
+			groupName:            "fah0a",
+
+			expectedPath: "/certificates/fah0a-key.pem",
 		},
 	}
 
 	for index, test := range tests {
-		path := KeyPath(test.groupName)
+		path := KeyPath(test.certificateDirectory, test.groupName)
 
 		if !reflect.DeepEqual(test.expectedPath, path) {
 			t.Fatalf(

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -26,7 +26,7 @@ func GetTarget(service v1.Service) model.LabelSet {
 
 // GetScrapeConfigs takes a list of Kubernetes Services,
 // and returns a list of Prometheus ScrapeConfigs.
-func GetScrapeConfigs(services []v1.Service) ([]config.ScrapeConfig, error) {
+func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]config.ScrapeConfig, error) {
 	filteredServices := FilterInvalidServices(services)
 	groupedServices := GroupServices(filteredServices)
 
@@ -42,9 +42,9 @@ func GetScrapeConfigs(services []v1.Service) ([]config.ScrapeConfig, error) {
 			Scheme:  httpsScheme,
 			HTTPClientConfig: config.HTTPClientConfig{
 				TLSConfig: config.TLSConfig{
-					CAFile:   key.CAPath(groupName),
-					CertFile: key.CrtPath(groupName),
-					KeyFile:  key.KeyPath(groupName),
+					CAFile:   key.CAPath(certificateDirectory, groupName),
+					CertFile: key.CrtPath(certificateDirectory, groupName),
+					KeyFile:  key.KeyPath(certificateDirectory, groupName),
 				},
 			},
 			ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -45,13 +45,17 @@ func Test_Prometheus_GetTarget(t *testing.T) {
 // Test_Prometheus_GetScrapeConfigs tests the GetScrapeConfigs function.
 func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 	tests := []struct {
-		services              []v1.Service
+		services             []v1.Service
+		certificateDirectory string
+
 		expectedScrapeConfigs []config.ScrapeConfig
 	}{
 		// Test that when there are no services available,
 		// no scrape configs are returned.
 		{
-			services:              nil,
+			services:             nil,
+			certificateDirectory: "/certs",
+
 			expectedScrapeConfigs: []config.ScrapeConfig{},
 		},
 
@@ -65,6 +69,8 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			certificateDirectory: "/certs",
+
 			expectedScrapeConfigs: []config.ScrapeConfig{},
 		},
 
@@ -83,6 +89,8 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			certificateDirectory: "/certs",
+
 			expectedScrapeConfigs: []config.ScrapeConfig{},
 		},
 
@@ -101,15 +109,17 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			certificateDirectory: "/certs",
+
 			expectedScrapeConfigs: []config.ScrapeConfig{
 				{
 					JobName: "xa5ly",
 					Scheme:  "https",
 					HTTPClientConfig: config.HTTPClientConfig{
 						TLSConfig: config.TLSConfig{
-							CAFile:             "/certs/xa5ly/ca.pem",
-							CertFile:           "/certs/xa5ly/crt.pem",
-							KeyFile:            "/certs/xa5ly/key.pem",
+							CAFile:             "/certs/xa5ly-ca.pem",
+							CertFile:           "/certs/xa5ly-crt.pem",
+							KeyFile:            "/certs/xa5ly-key.pem",
 							InsecureSkipVerify: false,
 						},
 					},
@@ -151,15 +161,17 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 				},
 			},
+			certificateDirectory: "/certs",
+
 			expectedScrapeConfigs: []config.ScrapeConfig{
 				{
 					JobName: "xa5ly",
 					Scheme:  "https",
 					HTTPClientConfig: config.HTTPClientConfig{
 						TLSConfig: config.TLSConfig{
-							CAFile:             "/certs/xa5ly/ca.pem",
-							CertFile:           "/certs/xa5ly/crt.pem",
-							KeyFile:            "/certs/xa5ly/key.pem",
+							CAFile:             "/certs/xa5ly-ca.pem",
+							CertFile:           "/certs/xa5ly-crt.pem",
+							KeyFile:            "/certs/xa5ly-key.pem",
 							InsecureSkipVerify: false,
 						},
 					},
@@ -179,7 +191,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 	}
 
 	for index, test := range tests {
-		scrapeConfigs, err := GetScrapeConfigs(test.services)
+		scrapeConfigs, err := GetScrapeConfigs(test.services, test.certificateDirectory)
 		if err != nil {
 			t.Fatalf("%d: error returned creating scrape configs: %s\n", index, err)
 		}

--- a/service/resource/configmap/configmap.go
+++ b/service/resource/configmap/configmap.go
@@ -16,6 +16,7 @@ type Config struct {
 	K8sClient kubernetes.Interface
 	Logger    micrologger.Logger
 
+	CertificateDirectory string
 	// ConfigMapKey is the key in the configmap under which the prometheus configuration is held.
 	ConfigMapKey       string
 	ConfigMapName      string
@@ -27,9 +28,10 @@ func DefaultConfig() Config {
 		K8sClient: nil,
 		Logger:    nil,
 
-		ConfigMapKey:       "",
-		ConfigMapName:      "",
-		ConfigMapNamespace: "",
+		CertificateDirectory: "",
+		ConfigMapKey:         "",
+		ConfigMapName:        "",
+		ConfigMapNamespace:   "",
 	}
 }
 
@@ -37,9 +39,10 @@ type Resource struct {
 	k8sClient kubernetes.Interface
 	logger    micrologger.Logger
 
-	configMapKey       string
-	configMapName      string
-	configMapNamespace string
+	certificateDirectory string
+	configMapKey         string
+	configMapName        string
+	configMapNamespace   string
 }
 
 func New(config Config) (*Resource, error) {
@@ -50,6 +53,9 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
 
+	if config.CertificateDirectory == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.CertificateDirectory must not be empty")
+	}
 	if config.ConfigMapKey == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.ConfigMapKey must not be empty")
 	}
@@ -64,9 +70,10 @@ func New(config Config) (*Resource, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
-		configMapKey:       config.ConfigMapKey,
-		configMapName:      config.ConfigMapName,
-		configMapNamespace: config.ConfigMapNamespace,
+		certificateDirectory: config.CertificateDirectory,
+		configMapKey:         config.ConfigMapKey,
+		configMapName:        config.ConfigMapName,
+		configMapNamespace:   config.ConfigMapNamespace,
 	}
 
 	return resource, nil

--- a/service/resource/configmap/create_test.go
+++ b/service/resource/configmap/create_test.go
@@ -18,6 +18,7 @@ func Test_Resource_ConfigMap_GetCreateState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"
@@ -46,6 +47,7 @@ func Test_Resource_ConfigMap_ProcessCreateState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"

--- a/service/resource/configmap/current_test.go
+++ b/service/resource/configmap/current_test.go
@@ -65,6 +65,7 @@ func Test_Resource_ConfigMap_GetCurrentState(t *testing.T) {
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
 
+		resourceConfig.CertificateDirectory = "/certs"
 		resourceConfig.ConfigMapKey = "prometheus.yml"
 		resourceConfig.ConfigMapName = configMapName
 		resourceConfig.ConfigMapNamespace = configMapNamespace

--- a/service/resource/configmap/delete_test.go
+++ b/service/resource/configmap/delete_test.go
@@ -18,6 +18,7 @@ func Test_Resource_ConfigMap_GetDeleteState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"
@@ -46,6 +47,7 @@ func Test_Resource_ConfigMap_ProcessDeleteState(t *testing.T) {
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
 
+	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"
 	resourceConfig.ConfigMapName = "prometheus"
 	resourceConfig.ConfigMapNamespace = "monitoring"

--- a/service/resource/configmap/desired.go
+++ b/service/resource/configmap/desired.go
@@ -42,7 +42,7 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	}
 
 	r.logger.Log("debug", fmt.Sprintf("computing desired state of configmap"))
-	scrapeConfigs, err := prometheus.GetScrapeConfigs(services.Items)
+	scrapeConfigs, err := prometheus.GetScrapeConfigs(services.Items, r.certificateDirectory)
 	if err != nil {
 		return nil, microerror.Maskf(err, "an error occurred creating scrape configs")
 	}

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -221,9 +221,9 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
 							TLSConfig: config.TLSConfig{
-								CAFile:             "/certs/xa5ly/ca.pem",
-								CertFile:           "/certs/xa5ly/crt.pem",
-								KeyFile:            "/certs/xa5ly/key.pem",
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
 								InsecureSkipVerify: false,
 							},
 						},
@@ -251,6 +251,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
 
+		resourceConfig.CertificateDirectory = "/certs"
 		resourceConfig.ConfigMapKey = configMapKey
 		resourceConfig.ConfigMapName = configMapName
 		resourceConfig.ConfigMapNamespace = configMapNamespace

--- a/service/resource/configmap/update_test.go
+++ b/service/resource/configmap/update_test.go
@@ -181,6 +181,7 @@ func Test_Resource_ConfigMap_GetUpdateState(t *testing.T) {
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
 
+		resourceConfig.CertificateDirectory = "/certs"
 		resourceConfig.ConfigMapKey = configMapKey
 		resourceConfig.ConfigMapName = configMapName
 		resourceConfig.ConfigMapNamespace = configMapNamespace
@@ -369,6 +370,7 @@ func Test_Resource_ConfigMap_ProcessUpdateState(t *testing.T) {
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
 
+		resourceConfig.CertificateDirectory = "/certs"
 		resourceConfig.ConfigMapKey = configMapKey
 		resourceConfig.ConfigMapName = configMapName
 		resourceConfig.ConfigMapNamespace = configMapNamespace

--- a/service/service.go
+++ b/service/service.go
@@ -103,6 +103,7 @@ func New(config Config) (*Service, error) {
 		configMapConfig.K8sClient = newK8sClient
 		configMapConfig.Logger = config.Logger
 
+		configMapConfig.CertificateDirectory = config.Viper.GetString(config.Flag.Service.Resource.CertificateDirectory)
 		configMapConfig.ConfigMapKey = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Key)
 		configMapConfig.ConfigMapName = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Name)
 		configMapConfig.ConfigMapNamespace = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Namespace)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

The certificate directory needs to be the same for both the `configmap` and `certificate` resources (even if we don't use if for the `certificate` resource yet). So, this adds support for configuring it from flags. Idea is that we pass the same values through to the `certificate` resource when we need it.