### PR TITLE
Adds tests for create state

### DIFF
--- a/service/resource/certificate/create_test.go
+++ b/service/resource/certificate/create_test.go
@@ -1,13 +1,58 @@
 package certificate
 
 import (
+	"context"
 	"testing"
+
+	"github.com/spf13/afero"
+	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/giantswarm/micrologger/microloggertest"
 )
 
 // Test_Resource_Certificate_GetCreateState tests the GetCreateState method.
 func Test_Resource_Certificate_GetCreateState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	resourceConfig := DefaultConfig()
+
+	resourceConfig.Fs = fs
+	resourceConfig.Logger = microloggertest.New()
+
+	resourceConfig.CertificateDirectory = "/certs"
+
+	resource, err := New(resourceConfig)
+	if err != nil {
+		t.Fatalf("error returned creating resource: %s\n", err)
+	}
+
+	createState, err := resource.GetCreateState(context.TODO(), v1.Service{}, []certificateFile{}, []certificateFile{})
+	if err != nil {
+		t.Fatalf("error returned getting create state: %s\n", err)
+	}
+
+	if createState != nil {
+		t.Fatalf("create state should be nil, was: %#v", createState)
+	}
 }
 
 // Test_Resource_Certificate_ProcessCreateState tests the ProcessCreateState method.
 func Test_Resource_Certificate_ProcessCreateState(t *testing.T) {
+	fs := afero.NewMemMapFs()
+
+	resourceConfig := DefaultConfig()
+
+	resourceConfig.Fs = fs
+	resourceConfig.Logger = microloggertest.New()
+
+	resourceConfig.CertificateDirectory = "/certs"
+
+	resource, err := New(resourceConfig)
+	if err != nil {
+		t.Fatalf("error returned creating resource: %s\n", err)
+	}
+
+	if err := resource.ProcessCreateState(context.TODO(), v1.Service{}, []certificateFile{}); err != nil {
+		t.Fatalf("error returned processing create state: %s\n", err)
+	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR adds testing for `GetCreateState` and `ProcessCreateState`, essentially just asserting that they are no-ops.