### PR TITLE
Fixes annotation being invalid

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -5,7 +5,7 @@ import (
 )
 
 const (
-	ClusterAnnotation = "giantswarm.io/prometheus-config-controller/cluster"
+	ClusterAnnotation = "giantswarm.io/prometheus-cluster"
 )
 
 // GetClusterID returns the value of the cluster annotation.


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

The annotation regexp doesn't support multiple '/' characters, so let's shorten the annotation a little.
