### PR TITLE
Adds metric for number of certificates on disk

### DIFF
--- a/service/resource/certificate/current.go
+++ b/service/resource/certificate/current.go
@@ -32,5 +32,7 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 		})
 	}
 
+	certificateCount.Set(float64(len(certificateFiles)))
+
 	return certificateFiles, nil
 }

--- a/service/resource/certificate/metrics.go
+++ b/service/resource/certificate/metrics.go
@@ -1,0 +1,25 @@
+package certificate
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prometheusNamespace = "prometheus_config_controller"
+	prometheusSubsystem = "certificate_resource"
+)
+
+var (
+	certificateCount = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "certificate_count",
+			Help:      "Number of certificates on disk.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(certificateCount)
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR adds a Prometheus metric for the number of certificates currently written to the disk. The idea here is to validate that certificates are being correctly cleaned up over time.

e.g:
```
$ ls /certs
total 0
-rw-r--r--  1 root  wheel     0B 24 Oct 11:18 example.crt
```
```
$ curl -s localhost:8000/metrics 
...
# HELP prometheus_config_controller_certificate_resource_certificate_count Number of certificates on disk.
# TYPE prometheus_config_controller_certificate_resource_certificate_count gauge
prometheus_config_controller_certificate_resource_certificate_count 1
```