### PR TITLE
Adds metric for size of configmap

### DIFF
--- a/service/resource/configmap/current.go
+++ b/service/resource/configmap/current.go
@@ -27,5 +27,8 @@ func (r *Resource) GetCurrentState(ctx context.Context, obj interface{}) (interf
 	}
 
 	r.logger.Log("debug", "found configmap")
+
+	configmapSize.Set(float64(configMap.Size()))
+
 	return configMap, nil
 }

--- a/service/resource/configmap/metrics.go
+++ b/service/resource/configmap/metrics.go
@@ -1,0 +1,25 @@
+package configmap
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	prometheusNamespace = "prometheus_config_controller"
+	prometheusSubsystem = "configmap_resource"
+)
+
+var (
+	configmapSize = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "configmap_size",
+			Help:      "Size of the prometheus configmap.",
+		},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(configmapSize)
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR adds a metric that reports the size of the configmap. This provides a metric that we can monitor to make sure services in the configmap are being cleaned up.