### PR TITLE
Adds support for reloading prometheus configuration

### DIFF
--- a/flag/service/prometheus/prometheus.go
+++ b/flag/service/prometheus/prometheus.go
@@ -1,0 +1,5 @@
+package prometheus
+
+type Prometheus struct {
+	Address string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -3,11 +3,13 @@ package service
 import (
 	"github.com/giantswarm/prometheus-config-controller/flag/service/controller"
 	"github.com/giantswarm/prometheus-config-controller/flag/service/kubernetes"
+	"github.com/giantswarm/prometheus-config-controller/flag/service/prometheus"
 	"github.com/giantswarm/prometheus-config-controller/flag/service/resource"
 )
 
 type Service struct {
 	Controller controller.Controller
 	Kubernetes kubernetes.Kubernetes
+	Prometheus prometheus.Prometheus
 	Resource   resource.Resource
 }

--- a/main.go
+++ b/main.go
@@ -144,6 +144,8 @@ func mainWithError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 
+	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Address, "http://127.0.0.1:9090", "Address of Prometheus to reload.")
+
 	daemonCommand.PersistentFlags().Int(f.Service.Resource.Retries, 3, "Number of times to retry resources.")
 
 	daemonCommand.PersistentFlags().String(f.Service.Resource.Certificate.ComponentName, "prometheus", "Component name label for certificates.")

--- a/service/prometheus/error.go
+++ b/service/prometheus/error.go
@@ -1,0 +1,19 @@
+package prometheus
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = microerror.New("invalid config")
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var reloadError = microerror.New("reload")
+
+// IsReloadError asserts reloadError.
+func IsReloadError(err error) bool {
+	return microerror.Cause(err) == reloadError
+}

--- a/service/prometheus/prometheustest/prometheustest.go
+++ b/service/prometheus/prometheustest/prometheustest.go
@@ -1,0 +1,12 @@
+// Package prometheustest provides a test implementation of the PrometheusReloader interface.
+package prometheustest
+
+type TestService struct{}
+
+func New() *TestService {
+	return &TestService{}
+}
+
+func (s *TestService) Reload() error {
+	return nil
+}

--- a/service/prometheus/service.go
+++ b/service/prometheus/service.go
@@ -1,0 +1,70 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+
+	Address string
+}
+
+func DefaultConfig() Config {
+	return Config{
+		Logger: nil,
+
+		Address: "",
+	}
+}
+
+type Service struct {
+	logger micrologger.Logger
+
+	// address is concatenated with the reload path in New.
+	address string
+}
+
+func New(config Config) (*Service, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+
+	if config.Address == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Address must not be empty")
+	}
+
+	u, err := url.ParseRequestURI(config.Address)
+	if err != nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Address is invalid: %s", err)
+	}
+	u.Path = path.Join(u.Path, prometheusReloadPath)
+
+	service := &Service{
+		logger: config.Logger,
+
+		address: u.String(),
+	}
+
+	return service, nil
+}
+
+func (s *Service) Reload() error {
+	s.logger.Log("debug", fmt.Sprintf("reloading prometheus config: %s", s.address))
+
+	res, err := http.Post(s.address, "", nil)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+	if res.StatusCode != http.StatusOK {
+		return microerror.Maskf(reloadError, "a non-200 status code was returned: %s", res.StatusCode)
+	}
+
+	return nil
+}

--- a/service/prometheus/service_test.go
+++ b/service/prometheus/service_test.go
@@ -1,0 +1,160 @@
+package prometheus
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+)
+
+// Test_Prometheus_New tests the New function.
+func Test_Prometheus_New(t *testing.T) {
+	tests := []struct {
+		config func() Config
+
+		expectedErrorHandler func(error) bool
+	}{
+		// Test that the default config returns an error.
+		{
+			config: DefaultConfig,
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that a logger must not be empty.
+		{
+			config: func() Config {
+				return Config{
+					Logger:  nil,
+					Address: "http://127.0.0.1:8080",
+				}
+			},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that the prometheus address must not be empty.
+		{
+			config: func() Config {
+				return Config{
+					Logger:  microloggertest.New(),
+					Address: "",
+				}
+			},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that the prometheus address must be valid.
+		{
+			config: func() Config {
+				return Config{
+					Logger:  microloggertest.New(),
+					Address: "jabberwocky",
+				}
+			},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that a valid config produces a service.
+		{
+			config: func() Config {
+				return Config{
+					Logger:  microloggertest.New(),
+					Address: "http://127.0.0.1:8080",
+				}
+			},
+
+			expectedErrorHandler: nil,
+		},
+	}
+
+	for index, test := range tests {
+		config := test.config()
+
+		service, err := New(config)
+		if err != nil && test.expectedErrorHandler == nil {
+			t.Fatalf("%d: unexpected error returned creating service: %s\n", index, err)
+		}
+		if err != nil && !test.expectedErrorHandler(err) {
+			t.Fatalf("%d: incorrect error returned creating service: %s\n", index, err)
+		}
+		if err == nil && test.expectedErrorHandler != nil {
+			t.Fatalf("%d: expected error not returned creating service\n", index)
+		}
+
+		if test.expectedErrorHandler == nil && service == nil {
+			t.Fatalf("%d: returned service was nil", index)
+		}
+	}
+}
+
+// Test_Prometheus_Reload tests the Reload method.
+func Test_Prometheus_Reload(t *testing.T) {
+	var receivedMessage *http.Request = nil
+
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedMessage = r
+	}))
+	defer testServer.Close()
+
+	defaultConfig := DefaultConfig()
+
+	defaultConfig.Logger = microloggertest.New()
+
+	defaultConfig.Address = testServer.URL
+
+	service, err := New(defaultConfig)
+	if err != nil {
+		t.Fatalf("error returned creating service: %s\n", err)
+	}
+
+	if err := service.Reload(); err != nil {
+		t.Fatalf("an error returned reloading prometheus: %s\n", err)
+	}
+
+	if receivedMessage == nil {
+		t.Fatalf("handler did not receive message")
+	}
+
+	if receivedMessage.Method != "POST" {
+		t.Fatalf("incorrect method used: %s\n", receivedMessage.Method)
+	}
+
+	if receivedMessage.URL.Path != "/-/reload" {
+		t.Fatalf("incorrect path used: %s\n", receivedMessage.URL.Path)
+	}
+}
+
+// Test_Prometheus_Reload_Failure tests the Reload method if the reload fails.
+// See https://github.com/prometheus/prometheus/blob/099df0c5f00c45c007a9779a2e4ab51cf4d076bf/web/web.go#L598
+// Prometheus returns http.StatusInternalServerError on error.
+func Test_Prometheus_Reload_Failure(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, fmt.Sprintf("beep boop i failed! D:"), http.StatusInternalServerError)
+	}))
+	defer testServer.Close()
+
+	defaultConfig := DefaultConfig()
+
+	defaultConfig.Logger = microloggertest.New()
+
+	defaultConfig.Address = testServer.URL
+
+	service, err := New(defaultConfig)
+	if err != nil {
+		t.Fatalf("error returned creating service: %s\n", err)
+	}
+
+	reloadErr := service.Reload()
+
+	if reloadErr == nil {
+		t.Fatalf("a nil error was returned\n")
+	}
+	if !IsReloadError(reloadErr) {
+		t.Fatalf("incorrect error returned: %s\n", reloadError)
+	}
+}

--- a/service/prometheus/spec.go
+++ b/service/prometheus/spec.go
@@ -1,0 +1,12 @@
+package prometheus
+
+const (
+	// prometheusReloadPath is the Prometheus API route that reloads the configuration
+	// when POSTed to.
+	prometheusReloadPath = "/-/reload"
+)
+
+// PrometheusReloader represents a service that can reload Prometheus configuration.
+type PrometheusReloader interface {
+	Reload() error
+}

--- a/service/resource/configmap/configmap.go
+++ b/service/resource/configmap/configmap.go
@@ -6,6 +6,8 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
 )
 
 const (
@@ -13,8 +15,9 @@ const (
 )
 
 type Config struct {
-	K8sClient kubernetes.Interface
-	Logger    micrologger.Logger
+	K8sClient          kubernetes.Interface
+	Logger             micrologger.Logger
+	PrometheusReloader prometheus.PrometheusReloader
 
 	CertificateDirectory string
 	// ConfigMapKey is the key in the configmap under which the prometheus configuration is held.
@@ -25,8 +28,9 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		K8sClient: nil,
-		Logger:    nil,
+		K8sClient:          nil,
+		Logger:             nil,
+		PrometheusReloader: nil,
 
 		CertificateDirectory: "",
 		ConfigMapKey:         "",
@@ -36,8 +40,9 @@ func DefaultConfig() Config {
 }
 
 type Resource struct {
-	k8sClient kubernetes.Interface
-	logger    micrologger.Logger
+	k8sClient          kubernetes.Interface
+	logger             micrologger.Logger
+	prometheusReloader prometheus.PrometheusReloader
 
 	certificateDirectory string
 	configMapKey         string
@@ -51,6 +56,9 @@ func New(config Config) (*Resource, error) {
 	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.PrometheusReloader == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.PrometheusReloader must not be empty")
 	}
 
 	if config.CertificateDirectory == "" {
@@ -67,8 +75,9 @@ func New(config Config) (*Resource, error) {
 	}
 
 	resource := &Resource{
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		k8sClient:          config.K8sClient,
+		logger:             config.Logger,
+		prometheusReloader: config.PrometheusReloader,
 
 		certificateDirectory: config.CertificateDirectory,
 		configMapKey:         config.ConfigMapKey,

--- a/service/resource/configmap/create_test.go
+++ b/service/resource/configmap/create_test.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_ConfigMap_GetCreateState tests the GetCreateState method.
@@ -17,6 +20,7 @@ func Test_Resource_ConfigMap_GetCreateState(t *testing.T) {
 
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"
@@ -46,6 +50,7 @@ func Test_Resource_ConfigMap_ProcessCreateState(t *testing.T) {
 
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"

--- a/service/resource/configmap/current_test.go
+++ b/service/resource/configmap/current_test.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_ConfigMap_GetCurrentState tests the GetCurrentState method.
@@ -64,6 +65,7 @@ func Test_Resource_ConfigMap_GetCurrentState(t *testing.T) {
 
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.PrometheusReloader = prometheustest.New()
 
 		resourceConfig.CertificateDirectory = "/certs"
 		resourceConfig.ConfigMapKey = "prometheus.yml"

--- a/service/resource/configmap/delete_test.go
+++ b/service/resource/configmap/delete_test.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/giantswarm/micrologger/microloggertest"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_ConfigMap_GetDeleteState tests the GetDeleteState method.
@@ -17,6 +19,7 @@ func Test_Resource_ConfigMap_GetDeleteState(t *testing.T) {
 
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"
@@ -46,6 +49,7 @@ func Test_Resource_ConfigMap_ProcessDeleteState(t *testing.T) {
 
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateDirectory = "/certs"
 	resourceConfig.ConfigMapKey = "prometheus.yml"

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/micrologger/microloggertest"
 
 	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_ConfigMap_GetDesiredState tests the GetDesiredState method.
@@ -249,6 +250,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.PrometheusReloader = prometheustest.New()
 
 		resourceConfig.CertificateDirectory = "/certs"
 		resourceConfig.ConfigMapKey = configMapKey

--- a/service/resource/configmap/update.go
+++ b/service/resource/configmap/update.go
@@ -66,6 +66,10 @@ func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState inte
 		}
 	}
 
+	if err := r.prometheusReloader.Reload(); err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR introduces support for reloading the prometheus configuration. We only need to do this when we change the configmap.