### PR TITLE
Fixes incorrect certificate removal

### DIFF
--- a/service/resource/certificate/update.go
+++ b/service/resource/certificate/update.go
@@ -31,7 +31,7 @@ func (r *Resource) GetUpdateState(ctx context.Context, obj, currentState, desire
 		return nil, nil, desiredCertificateFiles, nil
 	}
 
-	r.logger.Log("debug", "current certificates matches desired certificates, no update needed")
+	r.logger.Log("debug", "current certificates match desired certificates, no update needed")
 
 	return nil, nil, nil, nil
 }
@@ -40,6 +40,11 @@ func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState inte
 	updateCertificateFiles, err := toCertificateFiles(updateState)
 	if err != nil {
 		return microerror.Mask(err)
+	}
+
+	// In case the update state is nil, don't process at all.
+	if updateCertificateFiles == nil {
+		return nil
 	}
 
 	// Write the update state certificate files.

--- a/service/resource/certificate/update_test.go
+++ b/service/resource/certificate/update_test.go
@@ -330,6 +330,27 @@ func Test_Resource_Certificate_ProcessUpdateState(t *testing.T) {
 			expectedErrorHandler:     nil,
 		},
 
+		// Test that when the updateState is nil,
+		// and there is one certificate on disk,
+		// the certificate is not removed, and no error is returned.
+		{
+			currentCertificateFiles: []certificateFile{
+				{
+					path: "/certs/foo",
+					data: "foo",
+				},
+			},
+			updateState: nil,
+
+			expectedCertificateFiles: []certificateFile{
+				{
+					path: "/certs/foo",
+					data: "foo",
+				},
+			},
+			expectedErrorHandler: nil,
+		},
+
 		// Test that when the updateState contains one certificate,
 		// and there is one certificate on disk with different data,
 		// the certificate is updated, and no error is returned.
@@ -437,6 +458,10 @@ func Test_Resource_Certificate_ProcessUpdateState(t *testing.T) {
 		fileInfos, err := afero.ReadDir(fs, resourceConfig.CertificateDirectory)
 		if err != nil {
 			t.Fatalf("%d: error returned reading directory: %s\n", index, err)
+		}
+
+		if len(fileInfos) == 0 && len(test.expectedCertificateFiles) > 0 {
+			t.Fatalf("%d: expected certificates not found: %#v\n", index, test.expectedCertificateFiles)
 		}
 
 		for _, fileInfo := range fileInfos {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR fixes an issue where `ProcessUpdateState` was invoked with a `nil` updateState, which was interpreted as the desired state being _no_ certificates, therefore erroneously deleting certificates on disk.
We now differ between the nil list and the empty list, to determine between the two states.