### PR TITLE
Adds support for reloading config only when needed

### DIFF
--- a/service/prometheus/metrics.go
+++ b/service/prometheus/metrics.go
@@ -10,6 +10,24 @@ const (
 )
 
 var (
+	configurationReloadCheckCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "configuration_reload_check_count",
+			Help:      "Count of the times we have checked if a reload of the prometheus configuration is necessary.",
+		},
+	)
+
+	configurationReloadRequiredCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "configuration_reload_required_count",
+			Help:      "Count of the times we need to reload the prometheus configuration.",
+		},
+	)
+
 	configurationReloadCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: prometheusNamespace,
@@ -21,5 +39,7 @@ var (
 )
 
 func init() {
+	prometheus.MustRegister(configurationReloadCheckCount)
+	prometheus.MustRegister(configurationReloadRequiredCount)
 	prometheus.MustRegister(configurationReloadCount)
 }

--- a/service/prometheus/service.go
+++ b/service/prometheus/service.go
@@ -2,36 +2,58 @@ package prometheus
 
 import (
 	"fmt"
+	"html"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 )
 
 type Config struct {
-	Logger micrologger.Logger
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
 
 	Address string
+	// ConfigMapKey is the key in the configmap under which the prometheus configuration is held.
+	ConfigMapKey       string
+	ConfigMapName      string
+	ConfigMapNamespace string
 }
 
 func DefaultConfig() Config {
 	return Config{
-		Logger: nil,
+		K8sClient: nil,
+		Logger:    nil,
 
-		Address: "",
+		Address:            "",
+		ConfigMapKey:       "",
+		ConfigMapName:      "",
+		ConfigMapNamespace: "",
 	}
 }
 
 type Service struct {
-	logger micrologger.Logger
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
 
-	// address is concatenated with the reload path in New.
-	address string
+	// address is the address of the Prometheus instance we manage.
+	address            string
+	configMapKey       string
+	configMapName      string
+	configMapNamespace string
 }
 
 func New(config Config) (*Service, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
@@ -39,34 +61,171 @@ func New(config Config) (*Service, error) {
 	if config.Address == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Address must not be empty")
 	}
-
-	u, err := url.ParseRequestURI(config.Address)
-	if err != nil {
-		return nil, microerror.Maskf(invalidConfigError, "config.Address is invalid: %s", err)
+	if config.ConfigMapKey == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ConfigMapKey must not be empty")
 	}
-	u.Path = path.Join(u.Path, prometheusReloadPath)
+	if config.ConfigMapName == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ConfigMapName must not be empty")
+	}
+	if config.ConfigMapNamespace == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.ConfigMapNamespace must not be empty")
+	}
 
 	service := &Service{
-		logger: config.Logger,
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
 
-		address: u.String(),
+		address:            config.Address,
+		configMapKey:       config.ConfigMapKey,
+		configMapName:      config.ConfigMapName,
+		configMapNamespace: config.ConfigMapNamespace,
 	}
 
 	return service, nil
 }
 
 func (s *Service) Reload() error {
-	s.logger.Log("debug", fmt.Sprintf("reloading prometheus config: %s", s.address))
+	reloadRequired, err := s.isReloadRequired()
+	if err != nil {
+		return microerror.Maskf(reloadError, err.Error())
+	}
 
-	res, err := http.Post(s.address, "", nil)
+	if reloadRequired {
+		if err := s.reload(); err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	return nil
+}
+
+func (s *Service) isReloadRequired() (bool, error) {
+	s.logger.Log("debug", fmt.Sprintf("checking if reload is required"))
+
+	configurationReloadCheckCount.Inc()
+
+	currentConfigMapData, err := s.getCurrentConfigMapData()
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	currentConfiguration, err := s.getCurrentConfig()
+	if err != nil {
+		return false, microerror.Mask(err)
+	}
+
+	fmt.Printf("currentConfigMapData:\n%s\n", currentConfigMapData)
+	fmt.Printf("currentConfiguration:\n%s\n", currentConfiguration)
+
+	if currentConfigMapData != currentConfiguration {
+		configurationReloadRequiredCount.Inc()
+
+		s.logger.Log("debug", "configmap and current configuration do not match, reload required")
+		return true, nil
+	}
+
+	s.logger.Log("debug", "configmap and current configuration match, reload not required")
+	return false, nil
+}
+
+// getCurrentConfigMapData returns the configuration that is in the configmap.
+func (s *Service) getCurrentConfigMapData() (string, error) {
+	s.logger.Log("debug", fmt.Sprintf("fetching configmap: %s/%s", s.configMapNamespace, s.configMapName))
+
+	configMap, err := s.k8sClient.CoreV1().ConfigMaps(s.configMapNamespace).Get(
+		s.configMapName, metav1.GetOptions{},
+	)
+	if err != nil {
+		return "", microerror.Maskf(reloadError, err.Error())
+	}
+
+	val, ok := configMap.Data[s.configMapKey]
+	if !ok {
+		return "", microerror.Maskf(reloadError, "configmap key not present")
+	}
+
+	return val, nil
+}
+
+// getCurrentConfig returns the configuration that is currently loaded in Prometheus.
+func (s *Service) getCurrentConfig() (string, error) {
+	s.logger.Log("debug", "fetching current prometheus config")
+
+	configUrl, err := s.configUrl()
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	res, err := http.Get(configUrl)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", microerror.Maskf(reloadError, "a non-200 status code was returned: %d", res.StatusCode)
+	}
+
+	buf, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	defer res.Body.Close()
+
+	configPage := html.UnescapeString(string(buf))
+
+	startAnchor := "<pre>"
+	endAnchor := "</pre>"
+
+	if !strings.Contains(configPage, startAnchor) && !strings.Contains(configPage, endAnchor) {
+		return "", microerror.Maskf(reloadError, "required start and end anchors not found in configpage")
+	}
+
+	i := strings.Split(configPage, startAnchor)
+	j := strings.Split(i[1], endAnchor)
+
+	config := j[0]
+
+	return config, nil
+}
+
+func (s *Service) reload() error {
+	s.logger.Log("debug", "reloading prometheus config")
+
+	reloadUrl, err := s.reloadUrl()
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	res, err := http.Post(reloadUrl, "", nil)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 	if res.StatusCode != http.StatusOK {
-		return microerror.Maskf(reloadError, "a non-200 status code was returned: %s", res.StatusCode)
+		return microerror.Maskf(reloadError, "a non-200 status code was returned: %d", res.StatusCode)
 	}
 
 	configurationReloadCount.Inc()
 
 	return nil
+}
+
+// configUrl returns the url to fetch the current Prometheus configuration.
+func (s *Service) configUrl() (string, error) {
+	return s.getUrl(s.address, prometheusConfigPath)
+}
+
+// reloadUrl returns the url to reload the Prometheus configuration.
+func (s *Service) reloadUrl() (string, error) {
+	return s.getUrl(s.address, prometheusReloadPath)
+}
+
+// getUrl appends the given route to the address.
+func (s *Service) getUrl(address, route string) (string, error) {
+	u, err := url.ParseRequestURI(s.address)
+	if err != nil {
+		return "", microerror.Mask(err)
+	}
+	u.Path = path.Join(u.Path, route)
+
+	return u.String(), nil
 }

--- a/service/prometheus/spec.go
+++ b/service/prometheus/spec.go
@@ -1,6 +1,9 @@
 package prometheus
 
 const (
+	// prometheusConfigPath is the Prometheus route that returns the current
+	// configuration webpage.
+	prometheusConfigPath = "/config"
 	// prometheusReloadPath is the Prometheus API route that reloads the configuration
 	// when POSTed to.
 	prometheusReloadPath = "/-/reload"

--- a/service/resource/configmap/update.go
+++ b/service/resource/configmap/update.go
@@ -64,10 +64,12 @@ func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState inte
 		} else if err != nil {
 			return microerror.Mask(err)
 		}
+	}
 
-		if err := r.prometheusReloader.Reload(); err != nil {
-			return microerror.Mask(err)
-		}
+	// We attempt to reload Prometheus even if the configmap hasn't updated,
+	// as the PrometheusReloader takes care that we don't reload too often.
+	if err := r.prometheusReloader.Reload(); err != nil {
+		return microerror.Mask(err)
 	}
 
 	return nil

--- a/service/service.go
+++ b/service/service.go
@@ -114,9 +114,13 @@ func New(config Config) (*Service, error) {
 	{
 		prometheusConfig := prometheus.DefaultConfig()
 
+		prometheusConfig.K8sClient = newK8sClient
 		prometheusConfig.Logger = config.Logger
 
 		prometheusConfig.Address = config.Viper.GetString(config.Flag.Service.Prometheus.Address)
+		prometheusConfig.ConfigMapKey = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Key)
+		prometheusConfig.ConfigMapName = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Name)
+		prometheusConfig.ConfigMapNamespace = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Namespace)
 
 		newPrometheusReloader, err = prometheus.New(prometheusConfig)
 		if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR improves the prometheus reload support, by checking if the configuration that is currently loaded in Prometheus matches the configuration held in the configmap. It does this by fetching the Prometheus `/config` webpage and fishing the config out, and then comparing this with what is held in the configmap.

This fixes the issue where we reload prometheus (after updating the configmap with the prometheus-config-controller) before the configmap contents have been updated in the prometheus container, as we are now continuously asserting that the prometheus current state matches our desired state.

This functionality will be pulled out into a separate operator (`prometheus-reloader`) as part of the guest cluster scraping work.
