### PR TITLE
Fixes scrape config ordering

### DIFF
--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -59,6 +60,10 @@ func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]con
 
 		scrapeConfigs = append(scrapeConfigs, scrapeConfig)
 	}
+
+	sort.Slice(scrapeConfigs, func(i, j int) bool {
+		return scrapeConfigs[i].JobName < scrapeConfigs[j].JobName
+	})
 
 	return scrapeConfigs, nil
 }

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -378,28 +378,6 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 				},
 				ScrapeConfigs: []*config.ScrapeConfig{
 					{
-						JobName: "xa5ly",
-						Scheme:  "https",
-						HTTPClientConfig: config.HTTPClientConfig{
-							TLSConfig: config.TLSConfig{
-								CAFile:             "/certs/xa5ly-ca.pem",
-								CertFile:           "/certs/xa5ly-crt.pem",
-								KeyFile:            "/certs/xa5ly-key.pem",
-								InsecureSkipVerify: false,
-							},
-						},
-						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-							StaticConfigs: []*config.TargetGroup{
-								{
-									Targets: []model.LabelSet{
-										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-									},
-									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
-								},
-							},
-						},
-					},
-					{
 						JobName: "0ba9v",
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
@@ -415,6 +393,28 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								{
 									Targets: []model.LabelSet{
 										model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
+									},
+									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
+								},
+							},
+						},
+					},
+					{
+						JobName: "xa5ly",
+						Scheme:  "https",
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: false,
+							},
+						},
+						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+							StaticConfigs: []*config.TargetGroup{
+								{
+									Targets: []model.LabelSet{
+										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 									},
 									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
 								},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

Due to the use of a range over a map while generating the scrape configs, the order of scrape configs was non-deterministic. This caused unnecessary churn, as the desired state wasn't stable. This PR adds support for ordering scrape configs by the job name, making the configuration deterministic.