### PR TITLE
Adds rate limiting for prometheus reloading

### DIFF
--- a/flag/service/resource/configmap/configmap.go
+++ b/flag/service/resource/configmap/configmap.go
@@ -1,7 +1,8 @@
 package configmap
 
 type ConfigMap struct {
-	Key       string
-	Name      string
-	Namespace string
+	Key               string
+	Name              string
+	Namespace         string
+	MinimumReloadTime string
 }

--- a/main.go
+++ b/main.go
@@ -156,6 +156,7 @@ func mainWithError() error {
 	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Key, "prometheus.yml", "Key in configmap under which prometheus configuration is held.")
 	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Name, "prometheus", "Name of prometheus configmap to control.")
 	daemonCommand.PersistentFlags().String(f.Service.Resource.ConfigMap.Namespace, "monitoring", "Namespace of prometheus configmap to control.")
+	daemonCommand.PersistentFlags().Duration(f.Service.Resource.ConfigMap.MinimumReloadTime, 2*time.Minute, "Minimum time between reloads of Prometheus.")
 
 	daemonCommand.PersistentFlags().Duration(f.Service.Controller.ControllerBackOffDuration, time.Minute*5, "Maximum backoff duration for controller.")
 	daemonCommand.PersistentFlags().Duration(f.Service.Controller.FrameworkBackOffDuration, time.Minute*5, "Maximum backoff duration for operator framework.")

--- a/service/prometheus/metrics.go
+++ b/service/prometheus/metrics.go
@@ -19,6 +19,15 @@ var (
 		},
 	)
 
+	configurationReloadIgnoredCount = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: prometheusNamespace,
+			Subsystem: prometheusSubsystem,
+			Name:      "configuration_reload_ignored_count",
+			Help:      "Count of the times we have ignored a reload request due to rate limiting.",
+		},
+	)
+
 	configurationReloadRequiredCount = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: prometheusNamespace,
@@ -40,6 +49,7 @@ var (
 
 func init() {
 	prometheus.MustRegister(configurationReloadCheckCount)
+	prometheus.MustRegister(configurationReloadIgnoredCount)
 	prometheus.MustRegister(configurationReloadRequiredCount)
 	prometheus.MustRegister(configurationReloadCount)
 }

--- a/service/prometheus/service_test.go
+++ b/service/prometheus/service_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -39,6 +40,7 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "prometheus.yml",
 					ConfigMapName:      "prometheus",
 					ConfigMapNamespace: "monitoring",
+					MinimumReloadTime:  2 * time.Minute,
 				}
 			},
 
@@ -56,6 +58,7 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "prometheus.yml",
 					ConfigMapName:      "prometheus",
 					ConfigMapNamespace: "monitoring",
+					MinimumReloadTime:  2 * time.Minute,
 				}
 			},
 
@@ -73,6 +76,7 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "prometheus.yml",
 					ConfigMapName:      "prometheus",
 					ConfigMapNamespace: "monitoring",
+					MinimumReloadTime:  2 * time.Minute,
 				}
 			},
 
@@ -90,6 +94,7 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "",
 					ConfigMapName:      "prometheus",
 					ConfigMapNamespace: "monitoring",
+					MinimumReloadTime:  2 * time.Minute,
 				}
 			},
 
@@ -107,6 +112,7 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "prometheus.yml",
 					ConfigMapName:      "",
 					ConfigMapNamespace: "monitoring",
+					MinimumReloadTime:  2 * time.Minute,
 				}
 			},
 
@@ -124,6 +130,25 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "prometheus.yml",
 					ConfigMapName:      "prometheus",
 					ConfigMapNamespace: "",
+					MinimumReloadTime:  2 * time.Minute,
+				}
+			},
+
+			expectedErrorHandler: IsInvalidConfig,
+		},
+
+		// Test that the minimum reload time must not be zero.
+		{
+			config: func() Config {
+				return Config{
+					K8sClient: fake.NewSimpleClientset(),
+					Logger:    microloggertest.New(),
+
+					Address:            "http://127.0.0.1:8080",
+					ConfigMapKey:       "prometheus.yml",
+					ConfigMapName:      "prometheus",
+					ConfigMapNamespace: "",
+					MinimumReloadTime:  time.Duration(0),
 				}
 			},
 
@@ -141,6 +166,7 @@ func Test_Prometheus_New(t *testing.T) {
 					ConfigMapKey:       "prometheus.yml",
 					ConfigMapName:      "prometheus",
 					ConfigMapNamespace: "monitoring",
+					MinimumReloadTime:  2 * time.Minute,
 				}
 			},
 
@@ -366,6 +392,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 		prometheusReloaderConfig.ConfigMapKey = configMapKey
 		prometheusReloaderConfig.ConfigMapName = configMapName
 		prometheusReloaderConfig.ConfigMapNamespace = configMapNamespace
+		prometheusReloaderConfig.MinimumReloadTime = 1 * time.Second
 
 		service, err := New(prometheusReloaderConfig)
 		if err != nil {

--- a/service/service.go
+++ b/service/service.go
@@ -121,6 +121,7 @@ func New(config Config) (*Service, error) {
 		prometheusConfig.ConfigMapKey = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Key)
 		prometheusConfig.ConfigMapName = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Name)
 		prometheusConfig.ConfigMapNamespace = config.Viper.GetString(config.Flag.Service.Resource.ConfigMap.Namespace)
+		prometheusConfig.MinimumReloadTime = config.Viper.GetDuration(config.Flag.Service.Resource.ConfigMap.MinimumReloadTime)
 
 		newPrometheusReloader, err = prometheus.New(prometheusConfig)
 		if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR adds a hard limit to the frequency with which we reload Prometheus. This improves the situation where the `prometheus-config-controller` updates the configmap and requests multiple reloads of Prometheus, before Prometheus has had time to update itself. 

tl;dr - we reload when we need to, and not too often 