### PR TITLE
Adds prefix to job names

### DIFF
--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -14,6 +14,9 @@ import (
 const (
 	// httpsScheme is the scheme for https connections.
 	httpsScheme = "https"
+
+	// jobNamePrefix is the prefix for job names.
+	jobNamePrefix = "guest-cluster"
 )
 
 // GetTarget takes a Kubernetes Service, and returns a LabelSet,
@@ -39,7 +42,7 @@ func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]con
 		}
 
 		scrapeConfig := config.ScrapeConfig{
-			JobName: clusterID,
+			JobName: fmt.Sprintf("%s-%s", jobNamePrefix, clusterID),
 			Scheme:  httpsScheme,
 			HTTPClientConfig: config.HTTPClientConfig{
 				TLSConfig: config.TLSConfig{

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -92,7 +92,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 
 			expectedScrapeConfigs: []config.ScrapeConfig{
 				{
-					JobName: "xa5ly",
+					JobName: "guest-cluster-xa5ly",
 					Scheme:  "https",
 					HTTPClientConfig: config.HTTPClientConfig{
 						TLSConfig: config.TLSConfig{
@@ -142,7 +142,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 
 			expectedScrapeConfigs: []config.ScrapeConfig{
 				{
-					JobName: "0ba9v",
+					JobName: "guest-cluster-0ba9v",
 					Scheme:  "https",
 					HTTPClientConfig: config.HTTPClientConfig{
 						TLSConfig: config.TLSConfig{
@@ -164,7 +164,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 				},
 				{
-					JobName: "xa5ly",
+					JobName: "guest-cluster-xa5ly",
 					Scheme:  "https",
 					HTTPClientConfig: config.HTTPClientConfig{
 						TLSConfig: config.TLSConfig{
@@ -214,7 +214,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 
 			expectedScrapeConfigs: []config.ScrapeConfig{
 				{
-					JobName: "xa5ly",
+					JobName: "guest-cluster-xa5ly",
 					Scheme:  "https",
 					HTTPClientConfig: config.HTTPClientConfig{
 						TLSConfig: config.TLSConfig{
@@ -283,7 +283,7 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 
 	expectedScrapeConfigs := []config.ScrapeConfig{
 		{
-			JobName: "0ba9v",
+			JobName: "guest-cluster-0ba9v",
 			Scheme:  "https",
 			HTTPClientConfig: config.HTTPClientConfig{
 				TLSConfig: config.TLSConfig{
@@ -305,7 +305,7 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 			},
 		},
 		{
-			JobName: "xa5ly",
+			JobName: "guest-cluster-xa5ly",
 			Scheme:  "https",
 			HTTPClientConfig: config.HTTPClientConfig{
 				TLSConfig: config.TLSConfig{
@@ -354,7 +354,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 	}{
 		{
 			scrapeConfig: config.ScrapeConfig{
-				JobName: "xa5ly",
+				JobName: "guest-cluster-xa5ly",
 				Scheme:  "https",
 				HTTPClientConfig: config.HTTPClientConfig{
 					TLSConfig: config.TLSConfig{
@@ -376,7 +376,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 				},
 			},
 
-			expectedConfig: `job_name: xa5ly
+			expectedConfig: `job_name: guest-cluster-xa5ly
 scheme: https
 static_configs:
 - targets:

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -217,7 +217,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						Scheme:         "http",
 					},
 					{
-						JobName: "xa5ly",
+						JobName: "guest-cluster-xa5ly",
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
 							TLSConfig: config.TLSConfig{
@@ -260,7 +260,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						Scheme:         "http",
 					},
 					{
-						JobName: "xa5ly",
+						JobName: "guest-cluster-xa5ly",
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
 							TLSConfig: config.TLSConfig{
@@ -320,7 +320,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 				},
 				ScrapeConfigs: []*config.ScrapeConfig{
 					{
-						JobName: "xa5ly",
+						JobName: "guest-cluster-xa5ly",
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
 							TLSConfig: config.TLSConfig{
@@ -378,7 +378,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 				},
 				ScrapeConfigs: []*config.ScrapeConfig{
 					{
-						JobName: "0ba9v",
+						JobName: "guest-cluster-0ba9v",
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
 							TLSConfig: config.TLSConfig{
@@ -400,7 +400,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 					},
 					{
-						JobName: "xa5ly",
+						JobName: "guest-cluster-xa5ly",
 						Scheme:  "https",
 						HTTPClientConfig: config.HTTPClientConfig{
 							TLSConfig: config.TLSConfig{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

The Prometheus web ui orders jobs alphabetically, by job name. This PR adds a useful prefix that means guest clusters are sorted together in the web ui, as opposed to being split up by the other prometheus jobs.