### PR TITLE
Adds guest cluster label

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -5,11 +5,17 @@ import (
 )
 
 const (
+	// ClusterAnnotation is the Kubernetes annotation that identifies Services
+	// that the prometheus-config-controller should scrape.
 	ClusterAnnotation = "giantswarm.io/prometheus-cluster"
 
 	// ClusterLabel is the Prometheus label used to identify jobs
 	// managed by the prometheus-config-controller.
 	ClusterLabel = "prometheus_config_controller"
+
+	// ClusterIDLabel is the Prometheus label used to identify guest cluster
+	// metrics by external clients.
+	ClusterIDLabel = "cluster_id"
 )
 
 // GetClusterID returns the value of the cluster annotation.

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -55,7 +55,10 @@ func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]con
 				StaticConfigs: []*config.TargetGroup{
 					{
 						Targets: targets,
-						Labels:  model.LabelSet{ClusterLabel: ""},
+						Labels: model.LabelSet{
+							ClusterLabel:   "",
+							ClusterIDLabel: model.LabelValue(clusterID),
+						},
 					},
 				},
 			},

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -108,7 +108,10 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								Targets: []model.LabelSet{
 									model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 								},
-								Labels: model.LabelSet{ClusterLabel: ""},
+								Labels: model.LabelSet{
+									ClusterLabel:   "",
+									ClusterIDLabel: "xa5ly",
+								},
 							},
 						},
 					},
@@ -158,7 +161,10 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								Targets: []model.LabelSet{
 									model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
 								},
-								Labels: model.LabelSet{ClusterLabel: ""},
+								Labels: model.LabelSet{
+									ClusterLabel:   "",
+									ClusterIDLabel: "0ba9v",
+								},
 							},
 						},
 					},
@@ -180,7 +186,10 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								Targets: []model.LabelSet{
 									model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 								},
-								Labels: model.LabelSet{ClusterLabel: ""},
+								Labels: model.LabelSet{
+									ClusterLabel:   "",
+									ClusterIDLabel: "xa5ly",
+								},
 							},
 						},
 					},
@@ -231,7 +240,10 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 									model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 									model.LabelSet{model.AddressLabel: "kubelet.xa5ly"},
 								},
-								Labels: model.LabelSet{ClusterLabel: ""},
+								Labels: model.LabelSet{
+									ClusterLabel:   "",
+									ClusterIDLabel: "xa5ly",
+								},
 							},
 						},
 					},
@@ -299,7 +311,10 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 						Targets: []model.LabelSet{
 							model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
 						},
-						Labels: model.LabelSet{ClusterLabel: ""},
+						Labels: model.LabelSet{
+							ClusterLabel:   "",
+							ClusterIDLabel: "0ba9v",
+						},
 					},
 				},
 			},
@@ -321,7 +336,10 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 						Targets: []model.LabelSet{
 							model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 						},
-						Labels: model.LabelSet{ClusterLabel: ""},
+						Labels: model.LabelSet{
+							ClusterLabel:   "",
+							ClusterIDLabel: "xa5ly",
+						},
 					},
 				},
 			},
@@ -370,7 +388,10 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 							Targets: []model.LabelSet{
 								model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 							},
-							Labels: model.LabelSet{ClusterLabel: ""},
+							Labels: model.LabelSet{
+								ClusterLabel:   "",
+								ClusterIDLabel: "xa5ly",
+							},
 						},
 					},
 				},
@@ -382,6 +403,7 @@ static_configs:
 - targets:
   - apiserver.xa5ly
   labels:
+    cluster_id: xa5ly
     prometheus_config_controller: ""
 tls_config:
   ca_file: /certs/xa5ly-ca.pem

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -233,7 +233,10 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Targets: []model.LabelSet{
 										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 									},
-									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
+									Labels: model.LabelSet{
+										prometheus.ClusterLabel:   "",
+										prometheus.ClusterIDLabel: "xa5ly",
+									},
 								},
 							},
 						},
@@ -276,7 +279,10 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Targets: []model.LabelSet{
 										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 									},
-									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
+									Labels: model.LabelSet{
+										prometheus.ClusterLabel:   "",
+										prometheus.ClusterIDLabel: "xa5ly",
+									},
 								},
 							},
 						},
@@ -336,7 +342,10 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Targets: []model.LabelSet{
 										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 									},
-									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
+									Labels: model.LabelSet{
+										prometheus.ClusterLabel:   "",
+										prometheus.ClusterIDLabel: "xa5ly",
+									},
 								},
 							},
 						},
@@ -394,7 +403,10 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Targets: []model.LabelSet{
 										model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
 									},
-									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
+									Labels: model.LabelSet{
+										prometheus.ClusterLabel:   "",
+										prometheus.ClusterIDLabel: "0ba9v",
+									},
 								},
 							},
 						},
@@ -416,7 +428,10 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Targets: []model.LabelSet{
 										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
 									},
-									Labels: model.LabelSet{prometheus.ClusterLabel: ""},
+									Labels: model.LabelSet{
+										prometheus.ClusterLabel:   "",
+										prometheus.ClusterIDLabel: "xa5ly",
+									},
 								},
 							},
 						},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR adds the required labels for [desmotes](https://github.com/giantswarm/desmotes/) to fetch metrics for guest clusters.