### PR TITLE
Adds reload requests for certificate updates

### DIFF
--- a/service/prometheus/prometheustest/prometheustest.go
+++ b/service/prometheus/prometheustest/prometheustest.go
@@ -10,3 +10,5 @@ func New() *TestService {
 func (s *TestService) Reload() error {
 	return nil
 }
+
+func (s *TestService) RequestReload() {}

--- a/service/prometheus/spec.go
+++ b/service/prometheus/spec.go
@@ -11,5 +11,12 @@ const (
 
 // PrometheusReloader represents a service that can reload Prometheus configuration.
 type PrometheusReloader interface {
+	// Reload should reload the Prometheus configuration, possibly taking
+	// rate limiting into account.
 	Reload() error
+
+	// RequestReload should specify that the next call to Reload should force
+	// the reload to happen. Rate-limiting is allowed, but a reload must happen
+	// eventually.
+	RequestReload()
 }

--- a/service/resource/certificate/certificate.go
+++ b/service/resource/certificate/certificate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/framework"
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
 	"github.com/spf13/afero"
 	"k8s.io/client-go/kubernetes"
 )
@@ -15,9 +16,10 @@ const (
 )
 
 type Config struct {
-	Fs        afero.Fs
-	K8sClient kubernetes.Interface
-	Logger    micrologger.Logger
+	Fs                 afero.Fs
+	K8sClient          kubernetes.Interface
+	Logger             micrologger.Logger
+	PrometheusReloader prometheus.PrometheusReloader
 
 	CertificateComponentName string
 	CertificateDirectory     string
@@ -27,9 +29,10 @@ type Config struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Fs:        nil,
-		K8sClient: nil,
-		Logger:    nil,
+		Fs:                 nil,
+		K8sClient:          nil,
+		Logger:             nil,
+		PrometheusReloader: nil,
 
 		CertificateComponentName: "",
 		CertificateDirectory:     "",
@@ -39,9 +42,10 @@ func DefaultConfig() Config {
 }
 
 type Resource struct {
-	fs        afero.Fs
-	k8sClient kubernetes.Interface
-	logger    micrologger.Logger
+	fs                 afero.Fs
+	k8sClient          kubernetes.Interface
+	logger             micrologger.Logger
+	prometheusReloader prometheus.PrometheusReloader
 
 	certificateComponentName string
 	certificateDirectory     string
@@ -59,6 +63,9 @@ func New(config Config) (*Resource, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
 	}
+	if config.PrometheusReloader == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.PrometheusReloader must not be empty")
+	}
 
 	if config.CertificateComponentName == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.CertificateComponentName must not be empty")
@@ -74,9 +81,10 @@ func New(config Config) (*Resource, error) {
 	}
 
 	resource := &Resource{
-		fs:        config.Fs,
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		fs:                 config.Fs,
+		k8sClient:          config.K8sClient,
+		logger:             config.Logger,
+		prometheusReloader: config.PrometheusReloader,
 
 		certificateComponentName: config.CertificateComponentName,
 		certificateDirectory:     config.CertificateDirectory,

--- a/service/resource/certificate/create_test.go
+++ b/service/resource/certificate/create_test.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_Certificate_GetCreateState tests the GetCreateState method.
@@ -21,6 +23,7 @@ func Test_Resource_Certificate_GetCreateState(t *testing.T) {
 	resourceConfig.Fs = fs
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateComponentName = "prometheus"
 	resourceConfig.CertificateDirectory = "/certs"
@@ -52,6 +55,7 @@ func Test_Resource_Certificate_ProcessCreateState(t *testing.T) {
 	resourceConfig.Fs = fs
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateComponentName = "prometheus"
 	resourceConfig.CertificateDirectory = "/certs"

--- a/service/resource/certificate/current_test.go
+++ b/service/resource/certificate/current_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_Certificate_GetCurrentState tests the GetCurrentState method.
@@ -98,6 +100,7 @@ func Test_Resource_Certificate_GetCurrentState(t *testing.T) {
 		resourceConfig.Fs = fs
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.PrometheusReloader = prometheustest.New()
 
 		resourceConfig.CertificateComponentName = "prometheus"
 		resourceConfig.CertificateDirectory = test.certificateDirectory

--- a/service/resource/certificate/delete_test.go
+++ b/service/resource/certificate/delete_test.go
@@ -9,6 +9,8 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_Certificate_GetDeleteState tests the GetDeleteState method.
@@ -21,6 +23,7 @@ func Test_Resource_Certificate_GetDeleteState(t *testing.T) {
 	resourceConfig.Fs = fs
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateComponentName = "prometheus"
 	resourceConfig.CertificateDirectory = "/certs"
@@ -52,6 +55,7 @@ func Test_Resource_Certificate_ProcessDeleteState(t *testing.T) {
 	resourceConfig.Fs = fs
 	resourceConfig.K8sClient = fakeK8sClient
 	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
 
 	resourceConfig.CertificateComponentName = "prometheus"
 	resourceConfig.CertificateDirectory = "/certs"

--- a/service/resource/certificate/desired_test.go
+++ b/service/resource/certificate/desired_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/giantswarm/prometheus-config-controller/service/key"
 	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_Certificate_GetDesiredState tests the GetDesiredState method.
@@ -287,6 +288,7 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 		resourceConfig.Fs = fs
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.PrometheusReloader = prometheustest.New()
 
 		resourceConfig.CertificateComponentName = "prometheus"
 		resourceConfig.CertificateDirectory = test.certificateDirectory

--- a/service/resource/certificate/update.go
+++ b/service/resource/certificate/update.go
@@ -79,6 +79,9 @@ func (r *Resource) ProcessUpdateState(ctx context.Context, obj, updateState inte
 		}
 	}
 
+	r.logger.Log("debug", "certificates have been updated, requesting reload")
+	r.prometheusReloader.RequestReload()
+
 	return nil
 }
 

--- a/service/resource/certificate/update_test.go
+++ b/service/resource/certificate/update_test.go
@@ -12,6 +12,8 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/giantswarm/micrologger/microloggertest"
+
+	"github.com/giantswarm/prometheus-config-controller/service/prometheus/prometheustest"
 )
 
 // Test_Resource_Certificate_GetUpdateState tests the GetUpdateState method.
@@ -157,6 +159,7 @@ func Test_Resource_Certificate_GetUpdateState(t *testing.T) {
 		resourceConfig.Fs = fs
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.PrometheusReloader = prometheustest.New()
 
 		resourceConfig.CertificateComponentName = "prometheus"
 		resourceConfig.CertificateDirectory = "/certs"
@@ -422,6 +425,7 @@ func Test_Resource_Certificate_ProcessUpdateState(t *testing.T) {
 		resourceConfig.Fs = fs
 		resourceConfig.K8sClient = fakeK8sClient
 		resourceConfig.Logger = microloggertest.New()
+		resourceConfig.PrometheusReloader = prometheustest.New()
 
 		resourceConfig.CertificateComponentName = "prometheus"
 		resourceConfig.CertificateDirectory = "/certs"

--- a/service/service.go
+++ b/service/service.go
@@ -136,6 +136,7 @@ func New(config Config) (*Service, error) {
 		certificateConfig.Fs = newFs
 		certificateConfig.K8sClient = newK8sClient
 		certificateConfig.Logger = config.Logger
+		certificateConfig.PrometheusReloader = newPrometheusReloader
 
 		certificateConfig.CertificateComponentName = config.Viper.GetString(config.Flag.Service.Resource.Certificate.ComponentName)
 		certificateConfig.CertificateDirectory = config.Viper.GetString(config.Flag.Service.Resource.Certificate.Directory)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This fixes the scrape issue which resulted in the error message:
```
Get https://master.sf1ek:443/metrics: x509: certificate signed by unknown authority
```

The root cause was that when prometheus container started, and the configmap already had guest cluster configuration in, the certificates were not available yet, as the prometheus-config-controller did not have enough time to fetch and write them.
As prometheus only creates http client once per reload, it would not have the CA file present, which caused the x509 issue. This explains why reloading / creating a new guest cluster fixed the issue.

We now have an option to request a reload from the prometheus reloader, which (if rate limiting allows) forces the configuration to be reloaded, even if the configmap and prometheus config are the same. This reload is requested when the certificates are written.

Now, at boot, prometheus will start, and will be reloaded once the certificates are written.

Verified reload count via metrics, e.g: `prometheus_config_controller_prometheus_reloader_configuration_reload_count` == 1