### PR TITLE
Adds support for scraping kubelets

### DIFF
--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -82,6 +82,16 @@ func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]con
 					},
 				},
 			},
+			RelabelConfigs: []*config.RelabelConfig{
+				{
+					TargetLabel: ClusterLabel,
+					Replacement: ClusterLabel,
+				},
+				{
+					TargetLabel: ClusterIDLabel,
+					Replacement: clusterID,
+				},
+			},
 		}
 
 		scrapeConfigs = append(scrapeConfigs, scrapeConfig)

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -2,6 +2,7 @@ package prometheus
 
 import (
 	"fmt"
+	"net/url"
 	"sort"
 
 	"github.com/prometheus/common/model"
@@ -19,13 +20,16 @@ const (
 	jobNamePrefix = "guest-cluster"
 )
 
+func getTargetName(service v1.Service) string {
+	return fmt.Sprintf("%s.%s", service.Name, service.Namespace)
+}
+
 // GetTarget takes a Kubernetes Service, and returns a LabelSet,
 // suitable for use as a target.
 func GetTarget(service v1.Service) model.LabelSet {
-	targetName := fmt.Sprintf("%s.%s", service.Name, service.Namespace)
-	target := model.LabelSet{model.AddressLabel: model.LabelValue(targetName)}
-
-	return target
+	return model.LabelSet{
+		model.AddressLabel: model.LabelValue(getTargetName(service)),
+	}
 }
 
 // GetScrapeConfigs takes a list of Kubernetes Services,
@@ -46,9 +50,10 @@ func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]con
 			Scheme:  httpsScheme,
 			HTTPClientConfig: config.HTTPClientConfig{
 				TLSConfig: config.TLSConfig{
-					CAFile:   key.CAPath(certificateDirectory, clusterID),
-					CertFile: key.CrtPath(certificateDirectory, clusterID),
-					KeyFile:  key.KeyPath(certificateDirectory, clusterID),
+					CAFile:             key.CAPath(certificateDirectory, clusterID),
+					CertFile:           key.CrtPath(certificateDirectory, clusterID),
+					KeyFile:            key.KeyPath(certificateDirectory, clusterID),
+					InsecureSkipVerify: true,
 				},
 			},
 			ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -58,6 +63,21 @@ func GetScrapeConfigs(services []v1.Service, certificateDirectory string) ([]con
 						Labels: model.LabelSet{
 							ClusterLabel:   "",
 							ClusterIDLabel: model.LabelValue(clusterID),
+						},
+					},
+				},
+				KubernetesSDConfigs: []*config.KubernetesSDConfig{
+					{
+						APIServer: config.URL{&url.URL{
+							Scheme: httpsScheme,
+							Host:   getTargetName(services[0]),
+						}},
+						Role: config.KubernetesRoleNode,
+						TLSConfig: config.TLSConfig{
+							CAFile:             key.CAPath(certificateDirectory, clusterID),
+							CertFile:           key.CrtPath(certificateDirectory, clusterID),
+							KeyFile:            key.KeyPath(certificateDirectory, clusterID),
+							InsecureSkipVerify: false,
 						},
 					},
 				},

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -132,6 +132,16 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							},
 						},
 					},
+					RelabelConfigs: []*config.RelabelConfig{
+						{
+							TargetLabel: ClusterLabel,
+							Replacement: ClusterLabel,
+						},
+						{
+							TargetLabel: ClusterIDLabel,
+							Replacement: "xa5ly",
+						},
+					},
 				},
 			},
 		},
@@ -200,6 +210,16 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							},
 						},
 					},
+					RelabelConfigs: []*config.RelabelConfig{
+						{
+							TargetLabel: ClusterLabel,
+							Replacement: ClusterLabel,
+						},
+						{
+							TargetLabel: ClusterIDLabel,
+							Replacement: "0ba9v",
+						},
+					},
 				},
 				{
 					JobName: "guest-cluster-xa5ly",
@@ -238,6 +258,16 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 									InsecureSkipVerify: false,
 								},
 							},
+						},
+					},
+					RelabelConfigs: []*config.RelabelConfig{
+						{
+							TargetLabel: ClusterLabel,
+							Replacement: ClusterLabel,
+						},
+						{
+							TargetLabel: ClusterIDLabel,
+							Replacement: "xa5ly",
 						},
 					},
 				},
@@ -307,6 +337,16 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 									InsecureSkipVerify: false,
 								},
 							},
+						},
+					},
+					RelabelConfigs: []*config.RelabelConfig{
+						{
+							TargetLabel: ClusterLabel,
+							Replacement: ClusterLabel,
+						},
+						{
+							TargetLabel: ClusterIDLabel,
+							Replacement: "xa5ly",
 						},
 					},
 				},
@@ -395,6 +435,16 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 					},
 				},
 			},
+			RelabelConfigs: []*config.RelabelConfig{
+				{
+					TargetLabel: ClusterLabel,
+					Replacement: ClusterLabel,
+				},
+				{
+					TargetLabel: ClusterIDLabel,
+					Replacement: "0ba9v",
+				},
+			},
 		},
 		{
 			JobName: "guest-cluster-xa5ly",
@@ -433,6 +483,16 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 							InsecureSkipVerify: false,
 						},
 					},
+				},
+			},
+			RelabelConfigs: []*config.RelabelConfig{
+				{
+					TargetLabel: ClusterLabel,
+					Replacement: ClusterLabel,
+				},
+				{
+					TargetLabel: ClusterIDLabel,
+					Replacement: "xa5ly",
 				},
 			},
 		},
@@ -502,6 +562,16 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 						},
 					},
 				},
+				RelabelConfigs: []*config.RelabelConfig{
+					{
+						TargetLabel: ClusterLabel,
+						Replacement: ClusterLabel,
+					},
+					{
+						TargetLabel: ClusterIDLabel,
+						Replacement: "xa5ly",
+					},
+				},
 			},
 
 			expectedConfig: `job_name: guest-cluster-xa5ly
@@ -525,6 +595,13 @@ tls_config:
   cert_file: /certs/xa5ly-crt.pem
   key_file: /certs/xa5ly-key.pem
   insecure_skip_verify: true
+relabel_configs:
+- source_labels: []
+  target_label: prometheus_config_controller
+  replacement: prometheus_config_controller
+- source_labels: []
+  target_label: cluster_id
+  replacement: xa5ly
 `,
 		},
 	}
@@ -538,9 +615,11 @@ tls_config:
 		expectedLines := strings.Split(test.expectedConfig, "\n")
 		returnedLines := strings.Split(string(data), "\n")
 
-		for i := 0; i < len(expectedLines); i++ {
-			if expectedLines[i] != returnedLines[i] {
-				t.Logf("\nexpected line:\n'%s'\nreturned line:\n'%s'\n", expectedLines[i], returnedLines[i])
+		if len(expectedLines) == len(returnedLines) {
+			for i := 0; i < len(expectedLines); i++ {
+				if expectedLines[i] != returnedLines[i] {
+					t.Logf("\nexpected line:\n'%s'\nreturned line:\n'%s'\n", expectedLines[i], returnedLines[i])
+				}
 			}
 		}
 

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -101,7 +101,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							CAFile:             "/certs/xa5ly-ca.pem",
 							CertFile:           "/certs/xa5ly-crt.pem",
 							KeyFile:            "/certs/xa5ly-key.pem",
-							InsecureSkipVerify: false,
+							InsecureSkipVerify: true,
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -113,6 +113,21 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								Labels: model.LabelSet{
 									ClusterLabel:   "",
 									ClusterIDLabel: "xa5ly",
+								},
+							},
+						},
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
+							{
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.xa5ly",
+								}},
+								Role: config.KubernetesRoleNode,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/xa5ly-ca.pem",
+									CertFile:           "/certs/xa5ly-crt.pem",
+									KeyFile:            "/certs/xa5ly-key.pem",
+									InsecureSkipVerify: false,
 								},
 							},
 						},
@@ -154,7 +169,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							CAFile:             "/certs/0ba9v-ca.pem",
 							CertFile:           "/certs/0ba9v-crt.pem",
 							KeyFile:            "/certs/0ba9v-key.pem",
-							InsecureSkipVerify: false,
+							InsecureSkipVerify: true,
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -169,6 +184,21 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								},
 							},
 						},
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
+							{
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.0ba9v",
+								}},
+								Role: config.KubernetesRoleNode,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/0ba9v-ca.pem",
+									CertFile:           "/certs/0ba9v-crt.pem",
+									KeyFile:            "/certs/0ba9v-key.pem",
+									InsecureSkipVerify: false,
+								},
+							},
+						},
 					},
 				},
 				{
@@ -179,7 +209,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							CAFile:             "/certs/xa5ly-ca.pem",
 							CertFile:           "/certs/xa5ly-crt.pem",
 							KeyFile:            "/certs/xa5ly-key.pem",
-							InsecureSkipVerify: false,
+							InsecureSkipVerify: true,
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -191,6 +221,21 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								Labels: model.LabelSet{
 									ClusterLabel:   "",
 									ClusterIDLabel: "xa5ly",
+								},
+							},
+						},
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
+							{
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.xa5ly",
+								}},
+								Role: config.KubernetesRoleNode,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/xa5ly-ca.pem",
+									CertFile:           "/certs/xa5ly-crt.pem",
+									KeyFile:            "/certs/xa5ly-key.pem",
+									InsecureSkipVerify: false,
 								},
 							},
 						},
@@ -232,7 +277,7 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							CAFile:             "/certs/xa5ly-ca.pem",
 							CertFile:           "/certs/xa5ly-crt.pem",
 							KeyFile:            "/certs/xa5ly-key.pem",
-							InsecureSkipVerify: false,
+							InsecureSkipVerify: true,
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -245,6 +290,21 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 								Labels: model.LabelSet{
 									ClusterLabel:   "",
 									ClusterIDLabel: "xa5ly",
+								},
+							},
+						},
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
+							{
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.xa5ly",
+								}},
+								Role: config.KubernetesRoleNode,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/xa5ly-ca.pem",
+									CertFile:           "/certs/xa5ly-crt.pem",
+									KeyFile:            "/certs/xa5ly-key.pem",
+									InsecureSkipVerify: false,
 								},
 							},
 						},
@@ -304,7 +364,7 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 					CAFile:             "/certs/0ba9v-ca.pem",
 					CertFile:           "/certs/0ba9v-crt.pem",
 					KeyFile:            "/certs/0ba9v-key.pem",
-					InsecureSkipVerify: false,
+					InsecureSkipVerify: true,
 				},
 			},
 			ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -319,6 +379,21 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 						},
 					},
 				},
+				KubernetesSDConfigs: []*config.KubernetesSDConfig{
+					{
+						APIServer: config.URL{&url.URL{
+							Scheme: "https",
+							Host:   "apiserver.0ba9v",
+						}},
+						Role: config.KubernetesRoleNode,
+						TLSConfig: config.TLSConfig{
+							CAFile:             "/certs/0ba9v-ca.pem",
+							CertFile:           "/certs/0ba9v-crt.pem",
+							KeyFile:            "/certs/0ba9v-key.pem",
+							InsecureSkipVerify: false,
+						},
+					},
+				},
 			},
 		},
 		{
@@ -329,7 +404,7 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 					CAFile:             "/certs/xa5ly-ca.pem",
 					CertFile:           "/certs/xa5ly-crt.pem",
 					KeyFile:            "/certs/xa5ly-key.pem",
-					InsecureSkipVerify: false,
+					InsecureSkipVerify: true,
 				},
 			},
 			ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -341,6 +416,21 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 						Labels: model.LabelSet{
 							ClusterLabel:   "",
 							ClusterIDLabel: "xa5ly",
+						},
+					},
+				},
+				KubernetesSDConfigs: []*config.KubernetesSDConfig{
+					{
+						APIServer: config.URL{&url.URL{
+							Scheme: "https",
+							Host:   "apiserver.xa5ly",
+						}},
+						Role: config.KubernetesRoleNode,
+						TLSConfig: config.TLSConfig{
+							CAFile:             "/certs/xa5ly-ca.pem",
+							CertFile:           "/certs/xa5ly-crt.pem",
+							KeyFile:            "/certs/xa5ly-key.pem",
+							InsecureSkipVerify: false,
 						},
 					},
 				},

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -256,6 +256,16 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								},
 							},
 						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
+							},
+						},
 					},
 				},
 			},
@@ -315,6 +325,16 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 										InsecureSkipVerify: false,
 									},
 								},
+							},
+						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
 							},
 						},
 					},
@@ -395,6 +415,16 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								},
 							},
 						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
+							},
+						},
 					},
 				},
 			},
@@ -471,6 +501,16 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								},
 							},
 						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "0ba9v",
+							},
+						},
 					},
 					{
 						JobName: "guest-cluster-xa5ly",
@@ -509,6 +549,16 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 										InsecureSkipVerify: false,
 									},
 								},
+							},
+						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
 							},
 						},
 					},

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -2,6 +2,7 @@ package configmap
 
 import (
 	"context"
+	"net/url"
 	"testing"
 	"time"
 
@@ -224,7 +225,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								CAFile:             "/certs/xa5ly-ca.pem",
 								CertFile:           "/certs/xa5ly-crt.pem",
 								KeyFile:            "/certs/xa5ly-key.pem",
-								InsecureSkipVerify: false,
+								InsecureSkipVerify: true,
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -236,6 +237,21 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Labels: model.LabelSet{
 										prometheus.ClusterLabel:   "",
 										prometheus.ClusterIDLabel: "xa5ly",
+									},
+								},
+							},
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
 							},
@@ -270,7 +286,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								CAFile:             "/certs/xa5ly-ca.pem",
 								CertFile:           "/certs/xa5ly-crt.pem",
 								KeyFile:            "/certs/xa5ly-key.pem",
-								InsecureSkipVerify: false,
+								InsecureSkipVerify: true,
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -282,6 +298,21 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Labels: model.LabelSet{
 										prometheus.ClusterLabel:   "",
 										prometheus.ClusterIDLabel: "xa5ly",
+									},
+								},
+							},
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
 							},
@@ -333,7 +364,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								CAFile:             "/certs/xa5ly-ca.pem",
 								CertFile:           "/certs/xa5ly-crt.pem",
 								KeyFile:            "/certs/xa5ly-key.pem",
-								InsecureSkipVerify: false,
+								InsecureSkipVerify: true,
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -345,6 +376,21 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Labels: model.LabelSet{
 										prometheus.ClusterLabel:   "",
 										prometheus.ClusterIDLabel: "xa5ly",
+									},
+								},
+							},
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
 							},
@@ -394,7 +440,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								CAFile:             "/certs/0ba9v-ca.pem",
 								CertFile:           "/certs/0ba9v-crt.pem",
 								KeyFile:            "/certs/0ba9v-key.pem",
-								InsecureSkipVerify: false,
+								InsecureSkipVerify: true,
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -409,6 +455,21 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									},
 								},
 							},
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.0ba9v",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/0ba9v-ca.pem",
+										CertFile:           "/certs/0ba9v-crt.pem",
+										KeyFile:            "/certs/0ba9v-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+							},
 						},
 					},
 					{
@@ -419,7 +480,7 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								CAFile:             "/certs/xa5ly-ca.pem",
 								CertFile:           "/certs/xa5ly-crt.pem",
 								KeyFile:            "/certs/xa5ly-key.pem",
-								InsecureSkipVerify: false,
+								InsecureSkipVerify: true,
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
@@ -431,6 +492,21 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 									Labels: model.LabelSet{
 										prometheus.ClusterLabel:   "",
 										prometheus.ClusterIDLabel: "xa5ly",
+									},
+								},
+							},
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
 							},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

This PR enables the prometheus-config-controller to scrape kubelets for AWS/KVM. It does this by using the prometheus kubernetes service discovery, using the master service as an api server. 
