### PR TITLE
Scrape api server with kubernetes endpoint service discovery

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"github.com/prometheus/prometheus/config"
 	"k8s.io/api/core/v1"
 )
 
@@ -16,6 +17,30 @@ const (
 	// ClusterIDLabel is the Prometheus label used to identify guest cluster
 	// metrics by external clients.
 	ClusterIDLabel = "cluster_id"
+
+	// NamespaceLabel is the Prometheus label we use internally for an
+	// endpoints namespace.
+	NameLabel = "kubernetes_name"
+
+	// NamespaceLabel is the Prometheus label we use internally for
+	// an endpoints namespace.
+	NamespaceLabel = "kubernetes_namespace"
+
+	// PrometheusNamespaceLabel is the Prometheus label added by the Kubernetes
+	// service discovery to hold an endpoint targets namespace.
+	PrometheusNamespaceLabel = "__meta_kubernetes_namespace"
+
+	// PrometheusServiceNameLabel is the Prometheus label added by the Kubernetes
+	// service discovery to hold an endpoints service name.
+	PrometheusServiceNameLabel = "__meta_kubernetes_service_name"
+)
+
+var (
+	// EndpointRegexp is the regular expression against which endpoint service names
+	// must match to be scraped.
+	// The empty string is also matched, so that nodes (which have no service name),
+	// are also matched.
+	EndpointRegexp = config.MustNewRegexp(`((\s*|kubernetes))`)
 )
 
 // GetClusterID returns the value of the cluster annotation.

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -81,13 +81,37 @@ func getScrapeConfig(service v1.Service, certificateDirectory string) config.Scr
 			},
 		},
 		RelabelConfigs: []*config.RelabelConfig{
+			// Add the cluster label so we know this config is managed
+			// by the prometheus-config-controller.
 			{
 				TargetLabel: ClusterLabel,
 				Replacement: ClusterLabel,
+				Action:      config.RelabelReplace,
 			},
+			// Add the cluster id label, so we can identify the specific
+			// guest cluster.
 			{
 				TargetLabel: ClusterIDLabel,
 				Replacement: clusterID,
+				Action:      config.RelabelReplace,
+			},
+			// Copy the meta service name label to a named label.
+			{
+				SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+				TargetLabel:  NameLabel,
+				Action:       config.RelabelReplace,
+			},
+			// Copy the meta namespace name label to a named label.
+			{
+				SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+				TargetLabel:  NamespaceLabel,
+				Action:       config.RelabelReplace,
+			},
+			// Drop any targets that don't match the regexp.
+			{
+				SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+				Regex:        EndpointRegexp,
+				Action:       config.RelabelKeep,
 			},
 		},
 	}

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -41,42 +41,42 @@ func getTarget(service v1.Service) model.LabelSet {
 // getScrapeConfig takes a Service, and returns a ScrapeConfig.
 // It is assumed that filtering has already taken place, and the cluster annotation exists.
 func getScrapeConfig(service v1.Service, certificateDirectory string) config.ScrapeConfig {
-	clusterID := service.ObjectMeta.Annotations[ClusterAnnotation]
+	clusterID := GetClusterID(service)
+
+	apiServer := config.URL{&url.URL{
+		Scheme: httpsScheme,
+		Host:   getTargetHost(service),
+	}}
+
+	tlsConfig := config.TLSConfig{
+		CAFile:   key.CAPath(certificateDirectory, clusterID),
+		CertFile: key.CrtPath(certificateDirectory, clusterID),
+		KeyFile:  key.KeyPath(certificateDirectory, clusterID),
+	}
+
+	clientTlsConfig := tlsConfig
+	clientTlsConfig.InsecureSkipVerify = true
+
+	kubernetesTlsConfig := tlsConfig
+	kubernetesTlsConfig.InsecureSkipVerify = false
 
 	scrapeConfig := config.ScrapeConfig{
 		JobName: getJobName(service),
 		Scheme:  httpsScheme,
 		HTTPClientConfig: config.HTTPClientConfig{
-			TLSConfig: config.TLSConfig{
-				CAFile:             key.CAPath(certificateDirectory, clusterID),
-				CertFile:           key.CrtPath(certificateDirectory, clusterID),
-				KeyFile:            key.KeyPath(certificateDirectory, clusterID),
-				InsecureSkipVerify: true,
-			},
+			TLSConfig: clientTlsConfig,
 		},
 		ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-			StaticConfigs: []*config.TargetGroup{
-				{
-					Targets: []model.LabelSet{getTarget(service)},
-					Labels: model.LabelSet{
-						ClusterLabel:   "",
-						ClusterIDLabel: model.LabelValue(clusterID),
-					},
-				},
-			},
 			KubernetesSDConfigs: []*config.KubernetesSDConfig{
 				{
-					APIServer: config.URL{&url.URL{
-						Scheme: httpsScheme,
-						Host:   getTargetHost(service),
-					}},
-					Role: config.KubernetesRoleNode,
-					TLSConfig: config.TLSConfig{
-						CAFile:             key.CAPath(certificateDirectory, clusterID),
-						CertFile:           key.CrtPath(certificateDirectory, clusterID),
-						KeyFile:            key.KeyPath(certificateDirectory, clusterID),
-						InsecureSkipVerify: false,
-					},
+					APIServer: apiServer,
+					Role:      config.KubernetesRoleEndpoint,
+					TLSConfig: kubernetesTlsConfig,
+				},
+				{
+					APIServer: apiServer,
+					Role:      config.KubernetesRoleNode,
+					TLSConfig: kubernetesTlsConfig,
 				},
 			},
 		},

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -167,18 +167,20 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-						StaticConfigs: []*config.TargetGroup{
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
 							{
-								Targets: []model.LabelSet{
-									model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-								},
-								Labels: model.LabelSet{
-									ClusterLabel:   "",
-									ClusterIDLabel: "xa5ly",
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.xa5ly",
+								}},
+								Role: config.KubernetesRoleEndpoint,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/xa5ly-ca.pem",
+									CertFile:           "/certs/xa5ly-crt.pem",
+									KeyFile:            "/certs/xa5ly-key.pem",
+									InsecureSkipVerify: false,
 								},
 							},
-						},
-						KubernetesSDConfigs: []*config.KubernetesSDConfig{
 							{
 								APIServer: config.URL{&url.URL{
 									Scheme: "https",
@@ -245,18 +247,20 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-						StaticConfigs: []*config.TargetGroup{
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
 							{
-								Targets: []model.LabelSet{
-									model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
-								},
-								Labels: model.LabelSet{
-									ClusterLabel:   "",
-									ClusterIDLabel: "0ba9v",
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.0ba9v",
+								}},
+								Role: config.KubernetesRoleEndpoint,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/0ba9v-ca.pem",
+									CertFile:           "/certs/0ba9v-crt.pem",
+									KeyFile:            "/certs/0ba9v-key.pem",
+									InsecureSkipVerify: false,
 								},
 							},
-						},
-						KubernetesSDConfigs: []*config.KubernetesSDConfig{
 							{
 								APIServer: config.URL{&url.URL{
 									Scheme: "https",
@@ -295,18 +299,20 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						},
 					},
 					ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-						StaticConfigs: []*config.TargetGroup{
+						KubernetesSDConfigs: []*config.KubernetesSDConfig{
 							{
-								Targets: []model.LabelSet{
-									model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-								},
-								Labels: model.LabelSet{
-									ClusterLabel:   "",
-									ClusterIDLabel: "xa5ly",
+								APIServer: config.URL{&url.URL{
+									Scheme: "https",
+									Host:   "apiserver.xa5ly",
+								}},
+								Role: config.KubernetesRoleEndpoint,
+								TLSConfig: config.TLSConfig{
+									CAFile:             "/certs/xa5ly-ca.pem",
+									CertFile:           "/certs/xa5ly-crt.pem",
+									KeyFile:            "/certs/xa5ly-key.pem",
+									InsecureSkipVerify: false,
 								},
 							},
-						},
-						KubernetesSDConfigs: []*config.KubernetesSDConfig{
 							{
 								APIServer: config.URL{&url.URL{
 									Scheme: "https",
@@ -391,18 +397,20 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				},
 			},
 			ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-				StaticConfigs: []*config.TargetGroup{
+				KubernetesSDConfigs: []*config.KubernetesSDConfig{
 					{
-						Targets: []model.LabelSet{
-							model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
-						},
-						Labels: model.LabelSet{
-							ClusterLabel:   "",
-							ClusterIDLabel: "0ba9v",
+						APIServer: config.URL{&url.URL{
+							Scheme: "https",
+							Host:   "apiserver.0ba9v",
+						}},
+						Role: config.KubernetesRoleEndpoint,
+						TLSConfig: config.TLSConfig{
+							CAFile:             "/certs/0ba9v-ca.pem",
+							CertFile:           "/certs/0ba9v-crt.pem",
+							KeyFile:            "/certs/0ba9v-key.pem",
+							InsecureSkipVerify: false,
 						},
 					},
-				},
-				KubernetesSDConfigs: []*config.KubernetesSDConfig{
 					{
 						APIServer: config.URL{&url.URL{
 							Scheme: "https",
@@ -441,18 +449,20 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				},
 			},
 			ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-				StaticConfigs: []*config.TargetGroup{
+				KubernetesSDConfigs: []*config.KubernetesSDConfig{
 					{
-						Targets: []model.LabelSet{
-							model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-						},
-						Labels: model.LabelSet{
-							ClusterLabel:   "",
-							ClusterIDLabel: "xa5ly",
+						APIServer: config.URL{&url.URL{
+							Scheme: "https",
+							Host:   "apiserver.xa5ly",
+						}},
+						Role: config.KubernetesRoleEndpoint,
+						TLSConfig: config.TLSConfig{
+							CAFile:             "/certs/xa5ly-ca.pem",
+							CertFile:           "/certs/xa5ly-crt.pem",
+							KeyFile:            "/certs/xa5ly-key.pem",
+							InsecureSkipVerify: false,
 						},
 					},
-				},
-				KubernetesSDConfigs: []*config.KubernetesSDConfig{
 					{
 						APIServer: config.URL{&url.URL{
 							Scheme: "https",
@@ -518,18 +528,20 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 					},
 				},
 				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-					StaticConfigs: []*config.TargetGroup{
+					KubernetesSDConfigs: []*config.KubernetesSDConfig{
 						{
-							Targets: []model.LabelSet{
-								model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-							},
-							Labels: model.LabelSet{
-								ClusterLabel:   "",
-								ClusterIDLabel: "xa5ly",
+							APIServer: config.URL{&url.URL{
+								Scheme: "https",
+								Host:   "apiserver.xa5ly",
+							}},
+							Role: config.KubernetesRoleEndpoint,
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: false,
 							},
 						},
-					},
-					KubernetesSDConfigs: []*config.KubernetesSDConfig{
 						{
 							APIServer: config.URL{&url.URL{
 								Scheme: "https",
@@ -559,13 +571,14 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 
 			expectedConfig: `job_name: guest-cluster-xa5ly
 scheme: https
-static_configs:
-- targets:
-  - apiserver.xa5ly
-  labels:
-    cluster_id: xa5ly
-    prometheus_config_controller: ""
 kubernetes_sd_configs:
+- api_server: https://apiserver.xa5ly
+  role: endpoints
+  tls_config:
+    ca_file: /certs/xa5ly-ca.pem
+    cert_file: /certs/xa5ly-crt.pem
+    key_file: /certs/xa5ly-key.pem
+    insecure_skip_verify: false
 - api_server: https://apiserver.xa5ly
   role: node
   tls_config:

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -200,10 +200,27 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						{
 							TargetLabel: ClusterLabel,
 							Replacement: ClusterLabel,
+							Action:      config.RelabelReplace,
 						},
 						{
 							TargetLabel: ClusterIDLabel,
 							Replacement: "xa5ly",
+							Action:      config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							TargetLabel:  NameLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+							TargetLabel:  NamespaceLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							Regex:        EndpointRegexp,
+							Action:       config.RelabelKeep,
 						},
 					},
 				},
@@ -280,10 +297,27 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						{
 							TargetLabel: ClusterLabel,
 							Replacement: ClusterLabel,
+							Action:      config.RelabelReplace,
 						},
 						{
 							TargetLabel: ClusterIDLabel,
 							Replacement: "0ba9v",
+							Action:      config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							TargetLabel:  NameLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+							TargetLabel:  NamespaceLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							Regex:        EndpointRegexp,
+							Action:       config.RelabelKeep,
 						},
 					},
 				},
@@ -332,10 +366,27 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						{
 							TargetLabel: ClusterLabel,
 							Replacement: ClusterLabel,
+							Action:      config.RelabelReplace,
 						},
 						{
 							TargetLabel: ClusterIDLabel,
 							Replacement: "xa5ly",
+							Action:      config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							TargetLabel:  NameLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+							TargetLabel:  NamespaceLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							Regex:        EndpointRegexp,
+							Action:       config.RelabelKeep,
 						},
 					},
 				},
@@ -430,10 +481,27 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				{
 					TargetLabel: ClusterLabel,
 					Replacement: ClusterLabel,
+					Action:      config.RelabelReplace,
 				},
 				{
 					TargetLabel: ClusterIDLabel,
 					Replacement: "0ba9v",
+					Action:      config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+					TargetLabel:  NameLabel,
+					Action:       config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+					TargetLabel:  NamespaceLabel,
+					Action:       config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+					Regex:        EndpointRegexp,
+					Action:       config.RelabelKeep,
 				},
 			},
 		},
@@ -482,10 +550,27 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				{
 					TargetLabel: ClusterLabel,
 					Replacement: ClusterLabel,
+					Action:      config.RelabelReplace,
 				},
 				{
 					TargetLabel: ClusterIDLabel,
 					Replacement: "xa5ly",
+					Action:      config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+					TargetLabel:  NameLabel,
+					Action:       config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+					TargetLabel:  NamespaceLabel,
+					Action:       config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+					Regex:        EndpointRegexp,
+					Action:       config.RelabelKeep,
 				},
 			},
 		},
@@ -561,10 +646,27 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 					{
 						TargetLabel: ClusterLabel,
 						Replacement: ClusterLabel,
+						Action:      config.RelabelReplace,
 					},
 					{
 						TargetLabel: ClusterIDLabel,
 						Replacement: "xa5ly",
+						Action:      config.RelabelReplace,
+					},
+					{
+						SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+						TargetLabel:  NameLabel,
+						Action:       config.RelabelReplace,
+					},
+					{
+						SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
+						TargetLabel:  NamespaceLabel,
+						Action:       config.RelabelReplace,
+					},
+					{
+						SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+						Regex:        EndpointRegexp,
+						Action:       config.RelabelKeep,
 					},
 				},
 			},
@@ -595,9 +697,20 @@ relabel_configs:
 - source_labels: []
   target_label: prometheus_config_controller
   replacement: prometheus_config_controller
+  action: replace
 - source_labels: []
   target_label: cluster_id
   replacement: xa5ly
+  action: replace
+- source_labels: [__meta_kubernetes_service_name]
+  target_label: kubernetes_name
+  action: replace
+- source_labels: [__meta_kubernetes_namespace]
+  target_label: kubernetes_namespace
+  action: replace
+- source_labels: [__meta_kubernetes_service_name]
+  regex: ((\s*|kubernetes))
+  action: keep
 `,
 		},
 	}

--- a/service/prometheus/update.go
+++ b/service/prometheus/update.go
@@ -31,8 +31,15 @@ func UpdateConfig(promcfg config.Config, scrapeConfigs []config.ScrapeConfig) (c
 // isManaged returns true if the given scrape config is managed by the prometheus-config-controller,
 // false otherwise.
 func isManaged(scrapeConfig config.ScrapeConfig) bool {
+	// TODO: the static config detection can be removed once all installations use k8s sd.
 	for _, targetGroup := range scrapeConfig.ServiceDiscoveryConfig.StaticConfigs {
 		if _, ok := targetGroup.Labels[ClusterLabel]; ok {
+			return true
+		}
+	}
+
+	for _, relabelConfig := range scrapeConfig.RelabelConfigs {
+		if relabelConfig.TargetLabel == ClusterLabel {
 			return true
 		}
 	}

--- a/service/prometheus/update_test.go
+++ b/service/prometheus/update_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"net/url"
 	"reflect"
 	"testing"
 
@@ -47,6 +48,62 @@ func Test_Prometheus_isManaged(t *testing.T) {
 							},
 							Labels: model.LabelSet{ClusterLabel: ""},
 						},
+					},
+				},
+			},
+			isManaged: true,
+		},
+
+		{
+			scrapeConfig: config.ScrapeConfig{
+				JobName: "guest-cluster-xa5ly",
+				Scheme:  "https",
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						CAFile:             "/certs/xa5ly-ca.pem",
+						CertFile:           "/certs/xa5ly-crt.pem",
+						KeyFile:            "/certs/xa5ly-key.pem",
+						InsecureSkipVerify: true,
+					},
+				},
+				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+					KubernetesSDConfigs: []*config.KubernetesSDConfig{
+						{
+							APIServer: config.URL{&url.URL{
+								Scheme: "https",
+								Host:   "apiserver.xa5ly",
+							}},
+							Role: config.KubernetesRoleEndpoint,
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: false,
+							},
+						},
+						{
+							APIServer: config.URL{&url.URL{
+								Scheme: "https",
+								Host:   "apiserver.xa5ly",
+							}},
+							Role: config.KubernetesRoleNode,
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: false,
+							},
+						},
+					},
+				},
+				RelabelConfigs: []*config.RelabelConfig{
+					{
+						TargetLabel: ClusterLabel,
+						Replacement: ClusterLabel,
+					},
+					{
+						TargetLabel: ClusterIDLabel,
+						Replacement: "xa5ly",
 					},
 				},
 			},

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -229,18 +229,20 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-							StaticConfigs: []*config.TargetGroup{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
-									Targets: []model.LabelSet{
-										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-									},
-									Labels: model.LabelSet{
-										prometheus.ClusterLabel:   "",
-										prometheus.ClusterIDLabel: "xa5ly",
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
-							},
-							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
 									APIServer: config.URL{&url.URL{
 										Scheme: "https",
@@ -300,18 +302,20 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-							StaticConfigs: []*config.TargetGroup{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
-									Targets: []model.LabelSet{
-										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-									},
-									Labels: model.LabelSet{
-										prometheus.ClusterLabel:   "",
-										prometheus.ClusterIDLabel: "xa5ly",
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
-							},
-							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
 									APIServer: config.URL{&url.URL{
 										Scheme: "https",
@@ -388,18 +392,20 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-							StaticConfigs: []*config.TargetGroup{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
-									Targets: []model.LabelSet{
-										model.LabelSet{model.AddressLabel: "apiserver.xa5ly"},
-									},
-									Labels: model.LabelSet{
-										prometheus.ClusterLabel:   "",
-										prometheus.ClusterIDLabel: "xa5ly",
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
-							},
-							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
 									APIServer: config.URL{&url.URL{
 										Scheme: "https",
@@ -474,18 +480,20 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
-							StaticConfigs: []*config.TargetGroup{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
-									Targets: []model.LabelSet{
-										model.LabelSet{model.AddressLabel: "apiserver.0ba9v"},
-									},
-									Labels: model.LabelSet{
-										prometheus.ClusterLabel:   "",
-										prometheus.ClusterIDLabel: "0ba9v",
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.0ba9v",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/0ba9v-ca.pem",
+										CertFile:           "/certs/0ba9v-crt.pem",
+										KeyFile:            "/certs/0ba9v-key.pem",
+										InsecureSkipVerify: false,
 									},
 								},
-							},
-							KubernetesSDConfigs: []*config.KubernetesSDConfig{
 								{
 									APIServer: config.URL{&url.URL{
 										Scheme: "https",
@@ -524,6 +532,74 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+							},
+						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
+							},
+						},
+					},
+				},
+			},
+			expectedErrorHandler: nil,
+		},
+
+		// Test that if the configmap exists, with an older style scrape config,
+		// and the service exists,
+		// the configmap is updated with the newer scrape config.
+		// TODO: this test and support can be removed once the older static config
+		// style is removed everywhere.
+		{
+			setUpPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "guest-cluster-xa5ly",
+						Scheme:  "https",
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: true,
+							},
+						},
+						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
 							StaticConfigs: []*config.TargetGroup{
 								{
 									Targets: []model.LabelSet{
@@ -536,6 +612,85 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								},
 							},
 							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+							},
+						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
+							},
+						},
+					},
+				},
+			},
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			},
+			setUpServices: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "apiserver",
+						Namespace: "xa5ly",
+						Annotations: map[string]string{
+							prometheus.ClusterAnnotation: "xa5ly",
+						},
+					},
+				},
+			},
+
+			expectedPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval:     model.Duration(1 * time.Minute),
+					ScrapeTimeout:      model.Duration(10 * time.Second),
+					EvaluationInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "guest-cluster-xa5ly",
+						Scheme:  "https",
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: true,
+							},
+						},
+						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
 								{
 									APIServer: config.URL{&url.URL{
 										Scheme: "https",

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -262,10 +262,27 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								TargetLabel: prometheus.ClusterLabel,
 								Replacement: prometheus.ClusterLabel,
+								Action:      config.RelabelReplace,
 							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
+								Action:      config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
 							},
 						},
 					},
@@ -335,10 +352,27 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								TargetLabel: prometheus.ClusterLabel,
 								Replacement: prometheus.ClusterLabel,
+								Action:      config.RelabelReplace,
 							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
+								Action:      config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
 							},
 						},
 					},
@@ -425,10 +459,27 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								TargetLabel: prometheus.ClusterLabel,
 								Replacement: prometheus.ClusterLabel,
+								Action:      config.RelabelReplace,
 							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
+								Action:      config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
 							},
 						},
 					},
@@ -513,10 +564,27 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								TargetLabel: prometheus.ClusterLabel,
 								Replacement: prometheus.ClusterLabel,
+								Action:      config.RelabelReplace,
 							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "0ba9v",
+								Action:      config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
 							},
 						},
 					},
@@ -565,10 +633,27 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								TargetLabel: prometheus.ClusterLabel,
 								Replacement: prometheus.ClusterLabel,
+								Action:      config.RelabelReplace,
 							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
+								Action:      config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
 							},
 						},
 					},
@@ -710,10 +795,27 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								TargetLabel: prometheus.ClusterLabel,
 								Replacement: prometheus.ClusterLabel,
+								Action:      config.RelabelReplace,
 							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
+								Action:      config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
 							},
 						},
 					},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

We previously used a `StaticConfig` for scraping the api servers. However, as the api server exposes a Kubernetes endpoint, we can use kubernetes endpoint service discovery to discover them. This is more flexible in future when adding further services on a guest cluster we want to scrape.

This changset moves from using the static setup to the kubernetes service discovery.

<img width="1312" alt="screen shot 2017-12-14 at 17 28 49" src="https://user-images.githubusercontent.com/297653/34005878-4837342e-e0f4-11e7-8afc-bbe5cb033c86.png">
