### PR TITLE
Removes prometheus_config_controller label

### DIFF
--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -81,13 +81,6 @@ func getScrapeConfig(service v1.Service, certificateDirectory string) config.Scr
 			},
 		},
 		RelabelConfigs: []*config.RelabelConfig{
-			// Add the cluster label so we know this config is managed
-			// by the prometheus-config-controller.
-			{
-				TargetLabel: ClusterLabel,
-				Replacement: ClusterLabel,
-				Action:      config.RelabelReplace,
-			},
 			// Add the cluster id label, so we can identify the specific
 			// guest cluster.
 			{

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -198,11 +198,6 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 					RelabelConfigs: []*config.RelabelConfig{
 						{
-							TargetLabel: ClusterLabel,
-							Replacement: ClusterLabel,
-							Action:      config.RelabelReplace,
-						},
-						{
 							TargetLabel: ClusterIDLabel,
 							Replacement: "xa5ly",
 							Action:      config.RelabelReplace,
@@ -295,11 +290,6 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 					},
 					RelabelConfigs: []*config.RelabelConfig{
 						{
-							TargetLabel: ClusterLabel,
-							Replacement: ClusterLabel,
-							Action:      config.RelabelReplace,
-						},
-						{
 							TargetLabel: ClusterIDLabel,
 							Replacement: "0ba9v",
 							Action:      config.RelabelReplace,
@@ -363,11 +353,6 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						},
 					},
 					RelabelConfigs: []*config.RelabelConfig{
-						{
-							TargetLabel: ClusterLabel,
-							Replacement: ClusterLabel,
-							Action:      config.RelabelReplace,
-						},
 						{
 							TargetLabel: ClusterIDLabel,
 							Replacement: "xa5ly",
@@ -479,11 +464,6 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 			},
 			RelabelConfigs: []*config.RelabelConfig{
 				{
-					TargetLabel: ClusterLabel,
-					Replacement: ClusterLabel,
-					Action:      config.RelabelReplace,
-				},
-				{
 					TargetLabel: ClusterIDLabel,
 					Replacement: "0ba9v",
 					Action:      config.RelabelReplace,
@@ -547,11 +527,6 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				},
 			},
 			RelabelConfigs: []*config.RelabelConfig{
-				{
-					TargetLabel: ClusterLabel,
-					Replacement: ClusterLabel,
-					Action:      config.RelabelReplace,
-				},
 				{
 					TargetLabel: ClusterIDLabel,
 					Replacement: "xa5ly",
@@ -644,11 +619,6 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 				},
 				RelabelConfigs: []*config.RelabelConfig{
 					{
-						TargetLabel: ClusterLabel,
-						Replacement: ClusterLabel,
-						Action:      config.RelabelReplace,
-					},
-					{
 						TargetLabel: ClusterIDLabel,
 						Replacement: "xa5ly",
 						Action:      config.RelabelReplace,
@@ -694,10 +664,6 @@ tls_config:
   key_file: /certs/xa5ly-key.pem
   insecure_skip_verify: true
 relabel_configs:
-- source_labels: []
-  target_label: prometheus_config_controller
-  replacement: prometheus_config_controller
-  action: replace
 - source_labels: []
   target_label: cluster_id
   replacement: xa5ly

--- a/service/prometheus/update.go
+++ b/service/prometheus/update.go
@@ -38,8 +38,15 @@ func isManaged(scrapeConfig config.ScrapeConfig) bool {
 		}
 	}
 
+	// TODO: the clusterlabel can be removed once all installations use clusteridlabels.
 	for _, relabelConfig := range scrapeConfig.RelabelConfigs {
 		if relabelConfig.TargetLabel == ClusterLabel {
+			return true
+		}
+	}
+
+	for _, relabelConfig := range scrapeConfig.RelabelConfigs {
+		if relabelConfig.TargetLabel == ClusterIDLabel {
 			return true
 		}
 	}

--- a/service/prometheus/update_test.go
+++ b/service/prometheus/update_test.go
@@ -109,6 +109,58 @@ func Test_Prometheus_isManaged(t *testing.T) {
 			},
 			isManaged: true,
 		},
+
+		{
+			scrapeConfig: config.ScrapeConfig{
+				JobName: "guest-cluster-xa5ly",
+				Scheme:  "https",
+				HTTPClientConfig: config.HTTPClientConfig{
+					TLSConfig: config.TLSConfig{
+						CAFile:             "/certs/xa5ly-ca.pem",
+						CertFile:           "/certs/xa5ly-crt.pem",
+						KeyFile:            "/certs/xa5ly-key.pem",
+						InsecureSkipVerify: true,
+					},
+				},
+				ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+					KubernetesSDConfigs: []*config.KubernetesSDConfig{
+						{
+							APIServer: config.URL{&url.URL{
+								Scheme: "https",
+								Host:   "apiserver.xa5ly",
+							}},
+							Role: config.KubernetesRoleEndpoint,
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: false,
+							},
+						},
+						{
+							APIServer: config.URL{&url.URL{
+								Scheme: "https",
+								Host:   "apiserver.xa5ly",
+							}},
+							Role: config.KubernetesRoleNode,
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: false,
+							},
+						},
+					},
+				},
+				RelabelConfigs: []*config.RelabelConfig{
+					{
+						TargetLabel: ClusterIDLabel,
+						Replacement: "xa5ly",
+					},
+				},
+			},
+			isManaged: true,
+		},
 	}
 
 	for index, test := range tests {

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -260,11 +260,6 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 						RelabelConfigs: []*config.RelabelConfig{
 							{
-								TargetLabel: prometheus.ClusterLabel,
-								Replacement: prometheus.ClusterLabel,
-								Action:      config.RelabelReplace,
-							},
-							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
 								Action:      config.RelabelReplace,
@@ -349,11 +344,6 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						RelabelConfigs: []*config.RelabelConfig{
-							{
-								TargetLabel: prometheus.ClusterLabel,
-								Replacement: prometheus.ClusterLabel,
-								Action:      config.RelabelReplace,
-							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
@@ -457,11 +447,6 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 						RelabelConfigs: []*config.RelabelConfig{
 							{
-								TargetLabel: prometheus.ClusterLabel,
-								Replacement: prometheus.ClusterLabel,
-								Action:      config.RelabelReplace,
-							},
-							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
 								Action:      config.RelabelReplace,
@@ -562,11 +547,6 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 						RelabelConfigs: []*config.RelabelConfig{
 							{
-								TargetLabel: prometheus.ClusterLabel,
-								Replacement: prometheus.ClusterLabel,
-								Action:      config.RelabelReplace,
-							},
-							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "0ba9v",
 								Action:      config.RelabelReplace,
@@ -630,11 +610,6 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 						},
 						RelabelConfigs: []*config.RelabelConfig{
-							{
-								TargetLabel: prometheus.ClusterLabel,
-								Replacement: prometheus.ClusterLabel,
-								Action:      config.RelabelReplace,
-							},
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",
@@ -793,10 +768,179 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 						},
 						RelabelConfigs: []*config.RelabelConfig{
 							{
-								TargetLabel: prometheus.ClusterLabel,
-								Replacement: prometheus.ClusterLabel,
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
 								Action:      config.RelabelReplace,
 							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
+							},
+						},
+					},
+				},
+			},
+			expectedErrorHandler: nil,
+		},
+
+		// Test that if the configmap exists, with a prometheus_config_controller label,
+		// and the service exists,
+		// the configmap is updated without the prometheus_config_controller label.
+		// TODO: this test and support can be removed once the label
+		// style is removed everywhere.
+		{
+			setUpPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "guest-cluster-xa5ly",
+						Scheme:  "https",
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: true,
+							},
+						},
+						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+							},
+						},
+						RelabelConfigs: []*config.RelabelConfig{
+							{
+								TargetLabel: prometheus.ClusterLabel,
+								Replacement: prometheus.ClusterLabel,
+							},
+							{
+								TargetLabel: prometheus.ClusterIDLabel,
+								Replacement: "xa5ly",
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  prometheus.NameLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
+								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
+							},
+						},
+					},
+				},
+			},
+			setUpConfigMap: &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      configMapName,
+					Namespace: configMapNamespace,
+				},
+			},
+			setUpServices: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "apiserver",
+						Namespace: "xa5ly",
+						Annotations: map[string]string{
+							prometheus.ClusterAnnotation: "xa5ly",
+						},
+					},
+				},
+			},
+
+			expectedPrometheusConfiguration: &config.Config{
+				GlobalConfig: config.GlobalConfig{
+					ScrapeInterval:     model.Duration(1 * time.Minute),
+					ScrapeTimeout:      model.Duration(10 * time.Second),
+					EvaluationInterval: model.Duration(1 * time.Minute),
+				},
+				ScrapeConfigs: []*config.ScrapeConfig{
+					{
+						JobName: "guest-cluster-xa5ly",
+						Scheme:  "https",
+						HTTPClientConfig: config.HTTPClientConfig{
+							TLSConfig: config.TLSConfig{
+								CAFile:             "/certs/xa5ly-ca.pem",
+								CertFile:           "/certs/xa5ly-crt.pem",
+								KeyFile:            "/certs/xa5ly-key.pem",
+								InsecureSkipVerify: true,
+							},
+						},
+						ServiceDiscoveryConfig: config.ServiceDiscoveryConfig{
+							KubernetesSDConfigs: []*config.KubernetesSDConfig{
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleEndpoint,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+								{
+									APIServer: config.URL{&url.URL{
+										Scheme: "https",
+										Host:   "apiserver.xa5ly",
+									}},
+									Role: config.KubernetesRoleNode,
+									TLSConfig: config.TLSConfig{
+										CAFile:             "/certs/xa5ly-ca.pem",
+										CertFile:           "/certs/xa5ly-crt.pem",
+										KeyFile:            "/certs/xa5ly-key.pem",
+										InsecureSkipVerify: false,
+									},
+								},
+							},
+						},
+						RelabelConfigs: []*config.RelabelConfig{
 							{
 								TargetLabel: prometheus.ClusterIDLabel,
 								Replacement: "xa5ly",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

We were previously using the `prometheus_config_controller` label to determine whether a scrape config was managed by the `prometheus-config-controller`. However, we don't need this label, as we can use the `cluster_id` label instead, which cleans up the labels quite nicely.

<img width="1298" alt="screen shot 2017-12-15 at 14 04 49" src="https://user-images.githubusercontent.com/297653/34045500-05fd1166-e1a1-11e7-8d11-5cabdaeb367c.png">

look at it
look how tidy it is
*look at it*
