### PR TITLE
Adds support for scraping node-exporters

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -40,7 +40,11 @@ var (
 	// must match to be scraped.
 	// The empty string is also matched, so that nodes (which have no service name),
 	// are also matched.
-	EndpointRegexp = config.MustNewRegexp(`((\s*|kubernetes))`)
+	EndpointRegexp = config.MustNewRegexp(`(\s*|kubernetes|node-exporter)`)
+
+	// HTTPEndpointRegexp is the regular expression against which endpoint service
+	// names that we want to scrape via HTTP need to match.
+	HTTPEndpointRegexp = config.MustNewRegexp(`(node-exporter)`)
 )
 
 // GetClusterID returns the value of the cluster annotation.

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -13,8 +13,11 @@ import (
 )
 
 const (
-	// httpsScheme is the scheme for https connections.
-	httpsScheme = "https"
+	// HttpScheme is the scheme for http connections.
+	HttpScheme = "http"
+
+	// HttpsScheme is the scheme for https connections.
+	HttpsScheme = "https"
 
 	// jobNamePrefix is the prefix for job names.
 	jobNamePrefix = "guest-cluster"
@@ -44,7 +47,7 @@ func getScrapeConfig(service v1.Service, certificateDirectory string) config.Scr
 	clusterID := GetClusterID(service)
 
 	apiServer := config.URL{&url.URL{
-		Scheme: httpsScheme,
+		Scheme: HttpsScheme,
 		Host:   getTargetHost(service),
 	}}
 
@@ -62,7 +65,7 @@ func getScrapeConfig(service v1.Service, certificateDirectory string) config.Scr
 
 	scrapeConfig := config.ScrapeConfig{
 		JobName: getJobName(service),
-		Scheme:  httpsScheme,
+		Scheme:  HttpsScheme,
 		HTTPClientConfig: config.HTTPClientConfig{
 			TLSConfig: clientTlsConfig,
 		},
@@ -98,6 +101,14 @@ func getScrapeConfig(service v1.Service, certificateDirectory string) config.Scr
 			{
 				SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
 				TargetLabel:  NamespaceLabel,
+				Action:       config.RelabelReplace,
+			},
+			// Relabel http endpoints to scrape via http.
+			{
+				SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+				TargetLabel:  model.SchemeLabel,
+				Regex:        HTTPEndpointRegexp,
+				Replacement:  HttpScheme,
 				Action:       config.RelabelReplace,
 			},
 			// Drop any targets that don't match the regexp.

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -214,6 +214,13 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						},
 						{
 							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							TargetLabel:  model.SchemeLabel,
+							Regex:        HTTPEndpointRegexp,
+							Replacement:  HttpScheme,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 							Regex:        EndpointRegexp,
 							Action:       config.RelabelKeep,
 						},
@@ -306,6 +313,13 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						},
 						{
 							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							TargetLabel:  model.SchemeLabel,
+							Regex:        HTTPEndpointRegexp,
+							Replacement:  HttpScheme,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 							Regex:        EndpointRegexp,
 							Action:       config.RelabelKeep,
 						},
@@ -366,6 +380,13 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						{
 							SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
 							TargetLabel:  NamespaceLabel,
+							Action:       config.RelabelReplace,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+							TargetLabel:  model.SchemeLabel,
+							Regex:        HTTPEndpointRegexp,
+							Replacement:  HttpScheme,
 							Action:       config.RelabelReplace,
 						},
 						{
@@ -480,6 +501,13 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				},
 				{
 					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+					TargetLabel:  model.SchemeLabel,
+					Regex:        HTTPEndpointRegexp,
+					Replacement:  HttpScheme,
+					Action:       config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 					Regex:        EndpointRegexp,
 					Action:       config.RelabelKeep,
 				},
@@ -540,6 +568,13 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				{
 					SourceLabels: model.LabelNames{PrometheusNamespaceLabel},
 					TargetLabel:  NamespaceLabel,
+					Action:       config.RelabelReplace,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+					TargetLabel:  model.SchemeLabel,
+					Regex:        HTTPEndpointRegexp,
+					Replacement:  HttpScheme,
 					Action:       config.RelabelReplace,
 				},
 				{
@@ -635,6 +670,13 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 					},
 					{
 						SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
+						TargetLabel:  model.SchemeLabel,
+						Regex:        HTTPEndpointRegexp,
+						Replacement:  HttpScheme,
+						Action:       config.RelabelReplace,
+					},
+					{
+						SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 						Regex:        EndpointRegexp,
 						Action:       config.RelabelKeep,
 					},
@@ -675,7 +717,12 @@ relabel_configs:
   target_label: kubernetes_namespace
   action: replace
 - source_labels: [__meta_kubernetes_service_name]
-  regex: ((\s*|kubernetes))
+  regex: (node-exporter)
+  target_label: __scheme__
+  replacement: http
+  action: replace
+- source_labels: [__meta_kubernetes_service_name]
+  regex: (\s*|kubernetes|node-exporter)
   action: keep
 `,
 		},

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -276,6 +276,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
@@ -357,6 +364,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
 								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
 								Action:       config.RelabelReplace,
 							},
 							{
@@ -463,6 +477,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
@@ -563,6 +584,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							},
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
@@ -623,6 +651,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
 								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
 								Action:       config.RelabelReplace,
 							},
 							{
@@ -780,6 +815,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
 								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
 								Action:       config.RelabelReplace,
 							},
 							{
@@ -954,6 +996,13 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusNamespaceLabel},
 								TargetLabel:  prometheus.NamespaceLabel,
+								Action:       config.RelabelReplace,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
+								TargetLabel:  model.SchemeLabel,
+								Regex:        prometheus.HTTPEndpointRegexp,
+								Replacement:  prometheus.HttpScheme,
 								Action:       config.RelabelReplace,
 							},
 							{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/1482

Using HTTP for node-exporters and kube-state-metrics (see https://github.com/giantswarm/giantswarm/issues/1482#issuecomment-351951335 for discussion).
This PR adds support for scrapping HTTP endpoints, as well as adding node-exporters to the whitelist.