### PR TITLE
Drops any targets that do not match known ports

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -33,6 +33,10 @@ const (
 	// PrometheusServiceNameLabel is the Prometheus label added by the Kubernetes
 	// service discovery to hold an endpoints service name.
 	PrometheusServiceNameLabel = "__meta_kubernetes_service_name"
+
+	// PrometheusServicePortLabel is the Prometheus label added by the Kubernetes
+	// service discovery to hold an endpoints port.
+	PrometheusServicePortLabel = "__meta_kubernetes_pod_container_port_number"
 )
 
 var (
@@ -41,6 +45,12 @@ var (
 	// The empty string is also matched, so that nodes (which have no service name),
 	// are also matched.
 	EndpointRegexp = config.MustNewRegexp(`(\s*|kube-state-metrics|kubernetes|node-exporter)`)
+
+	// EndpointPortRegexp is the regular expression against which endpoint service ports
+	// must match to be scraped.
+	// We specify ports in the cases where users are running kube-state-metrics or node-exporters,
+	// to ensure we only scrape the correct instances.
+	EndpointPortRegexp = config.MustNewRegexp(`(\s*|443|10300|10301)`)
 
 	// HTTPEndpointRegexp is the regular expression against which endpoint service
 	// names that we want to scrape via HTTP need to match.

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -111,10 +111,16 @@ func getScrapeConfig(service v1.Service, certificateDirectory string) config.Scr
 				Replacement:  HttpScheme,
 				Action:       config.RelabelReplace,
 			},
-			// Drop any targets that don't match the regexp.
+			// Drop any targets that don't match the service name regexp.
 			{
 				SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 				Regex:        EndpointRegexp,
+				Action:       config.RelabelKeep,
+			},
+			// Drop any targets that don't match the service port regexp.
+			{
+				SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+				Regex:        EndpointPortRegexp,
 				Action:       config.RelabelKeep,
 			},
 		},

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -224,6 +224,11 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							Regex:        EndpointRegexp,
 							Action:       config.RelabelKeep,
 						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+							Regex:        EndpointPortRegexp,
+							Action:       config.RelabelKeep,
+						},
 					},
 				},
 			},
@@ -323,6 +328,11 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 							Regex:        EndpointRegexp,
 							Action:       config.RelabelKeep,
 						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+							Regex:        EndpointPortRegexp,
+							Action:       config.RelabelKeep,
+						},
 					},
 				},
 				{
@@ -392,6 +402,11 @@ func Test_Prometheus_GetScrapeConfigs(t *testing.T) {
 						{
 							SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 							Regex:        EndpointRegexp,
+							Action:       config.RelabelKeep,
+						},
+						{
+							SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+							Regex:        EndpointPortRegexp,
 							Action:       config.RelabelKeep,
 						},
 					},
@@ -511,6 +526,11 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 					Regex:        EndpointRegexp,
 					Action:       config.RelabelKeep,
 				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+					Regex:        EndpointPortRegexp,
+					Action:       config.RelabelKeep,
+				},
 			},
 		},
 		{
@@ -580,6 +600,11 @@ func Test_Prometheus_GetScrapeConfigs_Deterministic(t *testing.T) {
 				{
 					SourceLabels: model.LabelNames{PrometheusServiceNameLabel},
 					Regex:        EndpointRegexp,
+					Action:       config.RelabelKeep,
+				},
+				{
+					SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+					Regex:        EndpointPortRegexp,
 					Action:       config.RelabelKeep,
 				},
 			},
@@ -680,6 +705,11 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
 						Regex:        EndpointRegexp,
 						Action:       config.RelabelKeep,
 					},
+					{
+						SourceLabels: model.LabelNames{PrometheusServicePortLabel},
+						Regex:        EndpointPortRegexp,
+						Action:       config.RelabelKeep,
+					},
 				},
 			},
 
@@ -723,6 +753,9 @@ relabel_configs:
   action: replace
 - source_labels: [__meta_kubernetes_service_name]
   regex: (\s*|kube-state-metrics|kubernetes|node-exporter)
+  action: keep
+- source_labels: [__meta_kubernetes_pod_container_port_number]
+  regex: (\s*|443|10300|10301)
   action: keep
 `,
 		},

--- a/service/resource/configmap/desired_test.go
+++ b/service/resource/configmap/desired_test.go
@@ -286,6 +286,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
+								Action:       config.RelabelKeep,
+							},
 						},
 					},
 				},
@@ -376,6 +381,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
 								Action:       config.RelabelKeep,
 							},
 						},
@@ -487,6 +497,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
+								Action:       config.RelabelKeep,
+							},
 						},
 					},
 				},
@@ -594,6 +609,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
+								Action:       config.RelabelKeep,
+							},
 						},
 					},
 					{
@@ -663,6 +683,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
 								Action:       config.RelabelKeep,
 							},
 						},
@@ -829,6 +854,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 								Regex:        prometheus.EndpointRegexp,
 								Action:       config.RelabelKeep,
 							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
+								Action:       config.RelabelKeep,
+							},
 						},
 					},
 				},
@@ -910,6 +940,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
 								Action:       config.RelabelKeep,
 							},
 						},
@@ -1008,6 +1043,11 @@ func Test_Resource_ConfigMap_GetDesiredState(t *testing.T) {
 							{
 								SourceLabels: model.LabelNames{prometheus.PrometheusServiceNameLabel},
 								Regex:        prometheus.EndpointRegexp,
+								Action:       config.RelabelKeep,
+							},
+							{
+								SourceLabels: model.LabelNames{prometheus.PrometheusServicePortLabel},
+								Regex:        prometheus.EndpointPortRegexp,
 								Action:       config.RelabelKeep,
 							},
 						},


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2407

We have had an issue where a customer was running their own
kube-state-metrics, which the relabelling did not drop.
We only want to monitor our own services, so this changeset
only keeps services that match our port list.