### PR TITLE
Changes management check to use guest job name prefix

### DIFF
--- a/service/prometheus/update.go
+++ b/service/prometheus/update.go
@@ -1,6 +1,8 @@
 package prometheus
 
 import (
+	"strings"
+
 	"github.com/prometheus/prometheus/config"
 )
 
@@ -31,11 +33,5 @@ func UpdateConfig(promcfg config.Config, scrapeConfigs []config.ScrapeConfig) (c
 // isManaged returns true if the given scrape config is managed by the prometheus-config-controller,
 // false otherwise.
 func isManaged(scrapeConfig config.ScrapeConfig) bool {
-	for _, relabelConfig := range scrapeConfig.RelabelConfigs {
-		if relabelConfig.TargetLabel == ClusterIDLabel {
-			return true
-		}
-	}
-
-	return false
+	return strings.HasPrefix(scrapeConfig.JobName, jobNamePrefix)
 }

--- a/service/prometheus/update_test.go
+++ b/service/prometheus/update_test.go
@@ -88,6 +88,40 @@ func Test_Prometheus_isManaged(t *testing.T) {
 			},
 			isManaged: true,
 		},
+
+		{
+			scrapeConfig: config.ScrapeConfig{
+				JobName: "guest-cluster-xa5ly-cadvisor",
+				RelabelConfigs: []*config.RelabelConfig{
+					{
+						TargetLabel: ClusterIDLabel,
+						Replacement: "xa5ly",
+					},
+				},
+			},
+			isManaged: true,
+		},
+
+		{
+			scrapeConfig: config.ScrapeConfig{
+				JobName: "guest-cluster-xa5ly-cadvisor",
+			},
+			isManaged: true,
+		},
+
+		{
+			scrapeConfig: config.ScrapeConfig{
+				JobName: "host-cluster-gauss",
+			},
+			isManaged: false,
+		},
+
+		{
+			scrapeConfig: config.ScrapeConfig{
+				JobName: "host-cluster-gauss-cadvisor",
+			},
+			isManaged: false,
+		},
 	}
 
 	for index, test := range tests {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2395

We want to use the cluster_id label on host cluster jobs,
however previously the prometheus-config-controller would assume
these jobs were under its control, and remove them.

This changeset changes the management check to be whether the job
name starts with `guest-cluster-`, freeing up the cluster_id label.