### PR TITLE
Adds label selectors to service listing

### DIFF
--- a/service/controller/controller.go
+++ b/service/controller/controller.go
@@ -19,6 +19,11 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 )
 
+const (
+	// serviceLabelSelector is the label selector to match master services.
+	serviceLabelSelector = "app=master"
+)
+
 type Config struct {
 	BackOff           backoff.BackOff
 	K8sClient         kubernetes.Interface
@@ -113,10 +118,12 @@ func (o *Controller) bootWithError() error {
 	listWatch := &cache.ListWatch{
 		ListFunc: func(options apismetav1.ListOptions) (runtime.Object, error) {
 			o.logger.Log("debug", "listing all services", "event", "list")
+			options.LabelSelector = serviceLabelSelector
 			return o.k8sClient.CoreV1().Services("").List(options)
 		},
 		WatchFunc: func(options apismetav1.ListOptions) (watch.Interface, error) {
 			o.logger.Log("debug", "watching all services", "event", "watch")
+			options.LabelSelector = serviceLabelSelector
 			return o.k8sClient.CoreV1().Services("").Watch(options)
 		},
 	}

--- a/service/resource/certificate/desired.go
+++ b/service/resource/certificate/desired.go
@@ -17,13 +17,18 @@ const (
 	caKey  = "ca"  // CaKey is the key in the Secret that holds the CA.
 	crtKey = "crt" // CrtKey is the key in the Secret that holds the certificate.
 	keyKey = "key" // KeyKey is the key in the Secret that holds the key.
+
+	// ServiceLabelSelector is the label selector to match master services.
+	serviceLabelSelector = "app=master"
 )
 
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
 	r.logger.Log("debug", "fetching all services")
 
 	servicesTimer := prometheusclient.NewTimer(kubernetesResource.WithLabelValues("services", "list"))
-	services, err := r.k8sClient.CoreV1().Services("").List(metav1.ListOptions{})
+	services, err := r.k8sClient.CoreV1().Services("").List(metav1.ListOptions{
+		LabelSelector: serviceLabelSelector,
+	})
 	servicesTimer.ObserveDuration()
 
 	if err != nil {

--- a/service/resource/certificate/desired_test.go
+++ b/service/resource/certificate/desired_test.go
@@ -48,6 +48,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "foo",
 						Namespace: "default",
+						Labels: map[string]string{
+							"app": "master",
+						},
 					},
 				},
 			},
@@ -69,10 +72,51 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "xa5ly",
 						},
+						Labels: map[string]string{
+							"app": "master",
+						},
 					},
 				},
 			},
 			secrets: nil,
+
+			expectedCertificateFiles: nil,
+			expectedErrorHandler:     nil,
+		},
+
+		// Test that a service with a cluster annotation, and the certificate
+		// present, but the app=master label missing, does not return
+		// the certificates.
+		{
+			certificateDirectory: defaultCertificateDirectory,
+			services: []*v1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "apiserver",
+						Namespace: "xa5ly",
+						Annotations: map[string]string{
+							prometheus.ClusterAnnotation: "xa5ly",
+						},
+					},
+				},
+			},
+			secrets: []*v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "xa5ly-prometheus",
+						Namespace: "default",
+						Labels: map[string]string{
+							"clusterComponent": "prometheus",
+							"clusterID":        "xa5ly",
+						},
+					},
+					Data: map[string][]byte{
+						"ca":  []byte("foo"),
+						"crt": []byte("bar"),
+						"key": []byte("baz"),
+					},
+				},
+			},
 
 			expectedCertificateFiles: nil,
 			expectedErrorHandler:     nil,
@@ -91,6 +135,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "0ajf9",
 						},
+						Labels: map[string]string{
+							"app": "master",
+						},
 					},
 				},
 				{
@@ -99,6 +146,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Namespace: "xa5ly",
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "xa5ly",
+						},
+						Labels: map[string]string{
+							"app": "master",
 						},
 					},
 				},
@@ -150,6 +200,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "xa5ly",
 						},
+						Labels: map[string]string{
+							"app": "master",
+						},
 					},
 				},
 			},
@@ -192,6 +245,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Namespace: "xa5ly",
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "xa5ly",
+						},
+						Labels: map[string]string{
+							"app": "master",
 						},
 					},
 				},
@@ -243,6 +299,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "xa5ly",
 						},
+						Labels: map[string]string{
+							"app": "master",
+						},
 					},
 				},
 				{
@@ -251,6 +310,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Namespace: "al9qy",
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "al9qy",
+						},
+						Labels: map[string]string{
+							"app": "master",
 						},
 					},
 				},
@@ -309,6 +371,9 @@ func Test_Resource_Certificate_GetDesiredState(t *testing.T) {
 						Namespace: "xa5ly",
 						Annotations: map[string]string{
 							prometheus.ClusterAnnotation: "xa5ly",
+						},
+						Labels: map[string]string{
+							"app": "master",
 						},
 					},
 				},

--- a/service/resource/configmap/desired.go
+++ b/service/resource/configmap/desired.go
@@ -15,6 +15,11 @@ import (
 	"github.com/giantswarm/prometheus-config-controller/service/prometheus"
 )
 
+const (
+	// serviceLabelSelector is the label selector to match master services.
+	serviceLabelSelector = "app=master"
+)
+
 func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interface{}, error) {
 	r.logger.Log("debug", fmt.Sprintf("fetching configmap: %s/%s", r.configMapNamespace, r.configMapName))
 
@@ -43,7 +48,9 @@ func (r *Resource) GetDesiredState(ctx context.Context, obj interface{}) (interf
 	r.logger.Log("debug", fmt.Sprintf("fetching all services"))
 
 	servicesTimer := prometheusclient.NewTimer(kubernetesResource.WithLabelValues("services", "list"))
-	services, err := r.k8sClient.CoreV1().Services("").List(metav1.ListOptions{})
+	services, err := r.k8sClient.CoreV1().Services("").List(metav1.ListOptions{
+		LabelSelector: serviceLabelSelector,
+	})
 	servicesTimer.ObserveDuration()
 
 	if err != nil {


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2401

We are currently requesting all services, which is unnecessary. The master services we use all have this labelling, so we can only request the master services.