### PR TITLE
Removes label selector from listwatch

### DIFF
--- a/service/controller/controller.go
+++ b/service/controller/controller.go
@@ -19,11 +19,6 @@ import (
 	"github.com/giantswarm/operatorkit/framework"
 )
 
-const (
-	// serviceLabelSelector is the label selector to match master services.
-	serviceLabelSelector = "app=master"
-)
-
 type Config struct {
 	BackOff           backoff.BackOff
 	K8sClient         kubernetes.Interface
@@ -118,12 +113,10 @@ func (o *Controller) bootWithError() error {
 	listWatch := &cache.ListWatch{
 		ListFunc: func(options apismetav1.ListOptions) (runtime.Object, error) {
 			o.logger.Log("debug", "listing all services", "event", "list")
-			options.LabelSelector = serviceLabelSelector
 			return o.k8sClient.CoreV1().Services("").List(options)
 		},
 		WatchFunc: func(options apismetav1.ListOptions) (watch.Interface, error) {
 			o.logger.Log("debug", "watching all services", "event", "watch")
-			options.LabelSelector = serviceLabelSelector
 			return o.k8sClient.CoreV1().Services("").Watch(options)
 		},
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/2749

If we only watch for `app=master` services, if the last master service is deleted, we do no more work, so the last cluster is not deleted.
This PR removes the `app=master` filter from the list watch, so we always reconcile the prometheus configuration.