### PR TITLE
Remove bunch of metrics

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -115,16 +115,16 @@ var (
 	// Kubelet IP (including port), and capture the IP.
 	KubeletPortRegexp = config.MustNewRegexp(`(.*):10250`)
 
-	// KubeSystemRegexp is the regular expression to match against the kube-system namespace.
-	KubeSystemRegexp = config.MustNewRegexp(`kube-system`)
+	// KubeSystemGiantswarmNSRegexp is the regular expression to match against the kube-system and giantswarm namespace.
+	KubeSystemGiantswarmNSRegexp = config.MustNewRegexp(`(kube-system|giantswarm)`)
 
-	// MetricDropFStypeRegexp is the regular expression to match againts not interesting filesystem types.
+	// MetricDropFStypeRegexp is the regular expression to match againts not interesting filesystem (for node exporter metrics).
 	MetricDropFStypeRegexp = config.MustNewRegexp(`(cgroup|devpts|mqueue|nsfs|overlay|tmpfs)`)
 
-	// MetricDropSystemdStateRegexp is the regular expression to match againts not interesting systemd unit states.
+	// MetricDropSystemdStateRegexp is the regular expression to match againts not interesting systemd unit (for node exporter metrics).
 	MetricDropSystemdStateRegexp = config.MustNewRegexp(`node_systemd_unit_state;(active|activating|deactivating|inactive)`)
 
-	// MetricDropSystemdNameRegexp is the regulat expression to match against not interesting systemd units(docker mounts and calico network devices).
+	// MetricDropSystemdNameRegexp is the regular expression to match against not interesting systemd units(docker mounts and calico network devices).
 	MetricDropSystemdNameRegexp = config.MustNewRegexp(`node_systemd_unit_state;(dev-disk-by|run-docker-netns|sys-devices|sys-subsystem-net|var-lib-docker-overlay2|var-lib-docker-containers|var-lib-kubelet-pods).*`)
 
 	// NodeExporterRegexp is the regular expression to match against the

--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -35,6 +35,20 @@ var (
 	KubernetesSDServiceNameLabel = model.LabelName("__meta_kubernetes_service_name")
 )
 
+// Prometheus Kubernetes metrics labels.
+var (
+	// MetricNamespaceLabel is label for filtering by k8s namespace
+	MetricNamespaceLabel = model.LabelName("namespace")
+	// MetricNameLabel is label for filtering by metric name.
+	MetricNameLabel = model.LabelName("__name__")
+	// MetricSystemdNameLabel is a label for filtering by systemd unit name.
+	MetricSystemdNameLabel = model.LabelName("name")
+	// MetricSystemdStateLabel is a label for filtering by systemd unit state.
+	MetricSystemdStateLabel = model.LabelName("state")
+	// MetricFSTypeLabel is a label for filtering by mount filesystem type.
+	MetricFSTypeLabel = model.LabelName("fstype")
+)
+
 // Giant Swarm metrics schema labels.
 var (
 	// AppLabel is the label used to hold the application's name.
@@ -100,6 +114,18 @@ var (
 	// KubeletPortRegexp is the regular expression to match against the
 	// Kubelet IP (including port), and capture the IP.
 	KubeletPortRegexp = config.MustNewRegexp(`(.*):10250`)
+
+	// KubeSystemRegexp is the regular expression to match against the kube-system namespace.
+	KubeSystemRegexp = config.MustNewRegexp(`kube-system`)
+
+	// MetricDropFStypeRegexp is the regular expression to match againts not interesting filesystem types.
+	MetricDropFStypeRegexp = config.MustNewRegexp(`(cgroup|devpts|mqueue|nsfs|overlay|tmpfs)`)
+
+	// MetricDropSystemdStateRegexp is the regular expression to match againts not interesting systemd unit states.
+	MetricDropSystemdStateRegexp = config.MustNewRegexp(`node_systemd_unit_state;(active|activating|deactivating|inactive)`)
+
+	// MetricDropSystemdNameRegexp is the regulat expression to match against not interesting systemd units(docker mounts and calico network devices).
+	MetricDropSystemdNameRegexp = config.MustNewRegexp(`node_systemd_unit_state;(dev-disk-by|run-docker-netns|sys-devices|sys-subsystem-net|var-lib-docker-overlay2|var-lib-docker-containers|var-lib-kubelet-pods).*`)
 
 	// NodeExporterRegexp is the regular expression to match against the
 	// node-exporter name.

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -193,7 +193,7 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				{
 					Action:       ActionKeep,
 					SourceLabels: model.LabelNames{MetricNamespaceLabel},
-					Regex:        KubeSystemRegexp,
+					Regex:        KubeSystemGiantswarmNSRegexp,
 				},
 			},
 		},

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -31,6 +31,11 @@ const (
 	NodeExporterJobType = "node-exporter"
 	// WorkloadJobType is the job type for scraping general workloads.
 	WorkloadJobType = "workload"
+
+	// ActionKeep is action type that keeps only matching metrics.
+	ActionKeep = "keep"
+	// ActionDrop is action type that drops matching metrics.
+	ActionDrop = "drop"
 )
 
 // getJobName takes a cluster ID, and returns a suitable job name.
@@ -183,6 +188,14 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				roleLabelRelabelConfig,
 				missingRoleLabelRelabelConfig,
 			},
+			MetricRelabelConfigs: []*config.RelabelConfig{
+				// keep only kube-system cadvisor metrics
+				{
+					Action:       ActionKeep,
+					SourceLabels: model.LabelNames{MetricNamespaceLabel},
+					Regex:        KubeSystemRegexp,
+				},
+			},
 		},
 
 		{
@@ -244,6 +257,26 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 					Regex:        NodeExporterPortRegexp,
 					Replacement:  GroupCapture,
 					TargetLabel:  IPLabel,
+				},
+			},
+			MetricRelabelConfigs: []*config.RelabelConfig{
+				// Drop many mounts that are not interesting based on fstype.
+				{
+					Action:       ActionKeep,
+					SourceLabels: model.LabelNames{MetricFSTypeLabel},
+					Regex:        MetricDropFStypeRegexp,
+				},
+				// We care only about systemd state failed, we can drop the rest.
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel, MetricSystemdStateLabel},
+					Regex:        MetricDropSystemdStateRegexp,
+				},
+				// Drop all systemd units that are connected to docker mounts or networking, we don't care about them.
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel, MetricSystemdNameLabel},
+					Regex:        MetricDropSystemdNameRegexp,
 				},
 			},
 		},

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -361,6 +361,10 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     regex: null
     target_label: role
     replacement: worker
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: kube-system
+    action: keep
 - job_name: guest-cluster-xa5ly-kubelet
   scheme: https
   kubernetes_sd_configs:
@@ -425,6 +429,16 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     regex: (.*):10300
     target_label: ip
     replacement: ${1}
+  metric_relabel_configs:
+  - source_labels: [fstype]
+    regex: (cgroup|devpts|mqueue|nsfs|overlay|tmpfs)
+    action: keep
+  - source_labels: [__name__, state]
+    regex: node_systemd_unit_state;(active|activating|deactivating|inactive)
+    action: drop
+  - source_labels: [__name__, name]
+    regex: node_systemd_unit_state;(dev-disk-by|run-docker-netns|sys-devices|sys-subsystem-net|var-lib-docker-overlay2|var-lib-docker-containers|var-lib-kubelet-pods).*
+    action: drop
 - job_name: guest-cluster-xa5ly-workload
   scheme: http
   kubernetes_sd_configs:

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -363,7 +363,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     replacement: worker
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: kube-system
+    regex: (kube-system|giantswarm)
     action: keep
 - job_name: guest-cluster-xa5ly-kubelet
   scheme: https

--- a/service/prometheus/scrapeconfig_test_vars.go
+++ b/service/prometheus/scrapeconfig_test_vars.go
@@ -129,7 +129,7 @@ var (
 			{
 				Action:       ActionKeep,
 				SourceLabels: model.LabelNames{MetricNamespaceLabel},
-				Regex:        KubeSystemRegexp,
+				Regex:        KubeSystemGiantswarmNSRegexp,
 			},
 		},
 	}

--- a/service/prometheus/scrapeconfig_test_vars.go
+++ b/service/prometheus/scrapeconfig_test_vars.go
@@ -124,6 +124,14 @@ var (
 				TargetLabel:  RoleLabel,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// keep only kube-system cadvisor metrics
+			{
+				Action:       ActionKeep,
+				SourceLabels: model.LabelNames{MetricNamespaceLabel},
+				Regex:        KubeSystemRegexp,
+			},
+		},
 	}
 	TestConfigOneKubelet = config.ScrapeConfig{
 		JobName: "guest-cluster-xa5ly-kubelet",
@@ -234,6 +242,26 @@ var (
 				Regex:        NodeExporterPortRegexp,
 				Replacement:  GroupCapture,
 				TargetLabel:  IPLabel,
+			},
+		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// Drop many mounts that are not interesting based on fstype.
+			{
+				Action:       ActionKeep,
+				SourceLabels: model.LabelNames{MetricFSTypeLabel},
+				Regex:        MetricDropFStypeRegexp,
+			},
+			// We care only about systemd state failed, we can drop the rest.
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel, MetricSystemdStateLabel},
+				Regex:        MetricDropSystemdStateRegexp,
+			},
+			// Drop all systemd units that are connected to docker mounts or networking, we don't care about them.
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel, MetricSystemdNameLabel},
+				Regex:        MetricDropSystemdNameRegexp,
 			},
 		},
 	}

--- a/service/resource/configmap/desired_test_vars.go
+++ b/service/resource/configmap/desired_test_vars.go
@@ -126,6 +126,14 @@ var (
 				TargetLabel:  prometheus.RoleLabel,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// keep only kube-system cadvisor metrics
+			{
+				Action:       prometheus.ActionKeep,
+				SourceLabels: model.LabelNames{prometheus.MetricNamespaceLabel},
+				Regex:        prometheus.KubeSystemRegexp,
+			},
+		},
 	}
 	TestConfigOneKubelet = config.ScrapeConfig{
 		JobName: "guest-cluster-xa5ly-kubelet",
@@ -236,6 +244,26 @@ var (
 				Regex:        prometheus.NodeExporterPortRegexp,
 				Replacement:  prometheus.GroupCapture,
 				TargetLabel:  prometheus.IPLabel,
+			},
+		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// Drop many mounts that are not interesting based on fstype.
+			{
+				Action:       prometheus.ActionKeep,
+				SourceLabels: model.LabelNames{prometheus.MetricFSTypeLabel},
+				Regex:        prometheus.MetricDropFStypeRegexp,
+			},
+			// We care only about systemd state failed, we can drop the rest.
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel, prometheus.MetricSystemdStateLabel},
+				Regex:        prometheus.MetricDropSystemdStateRegexp,
+			},
+			// Drop all systemd units that are connected to docker mounts or networking, we don't care about them.
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel, prometheus.MetricSystemdNameLabel},
+				Regex:        prometheus.MetricDropSystemdNameRegexp,
 			},
 		},
 	}

--- a/service/resource/configmap/desired_test_vars.go
+++ b/service/resource/configmap/desired_test_vars.go
@@ -131,7 +131,7 @@ var (
 			{
 				Action:       prometheus.ActionKeep,
 				SourceLabels: model.LabelNames{prometheus.MetricNamespaceLabel},
-				Regex:        prometheus.KubeSystemRegexp,
+				Regex:        prometheus.KubeSystemGiantswarmNSRegexp,
 			},
 		},
 	}


### PR DESCRIPTION
So we are dropping a bunch of not interesting metrics here (similar to guest clusters)
### cadvisor
* dropping all guest cluster pod metrics, we just keep metrics from `kube-system`
```
      metric_relabel_configs:
      - source_labels: [namespace]
        separator: ;
        regex: kube-system
        replacement: $1
        action: keep
```
## node exporter
* dropping many mounts that are not interesting - there are many mounts via docker,kubelet magic that are completely useless to us lots of `tmpfs` and `overlay` mounts. Its really considerable big amount.
* we care only about systemd state failed there is alwasy 5 metrics per each systemd unit and we only care of state is failed, also big amount of metric here
* drop all systemd units that are connected to docker mounts or networking, we don't care about them - another big bunch of systemd unit states for docker mounts, kubelet mounts, calico network devices and more useless stuff
```
      metric_relabel_configs:
      - source_labels: [fstype]
        separator: ;
        regex: (cgroup|devpts|mqueue|nsfs|overlay|tmpfs)
        replacement: $1
        action: drop
      - source_labels: [__name__, state]
        separator: ;
        regex: node_systemd_unit_state;(active|activating|deactivating|inactive)
        replacement: $1
        action: drop
      - source_labels: [__name__, name]
        separator: ;
        regex: node_systemd_unit_state;(dev-disk-by|run-docker-netns|sys-devices|sys-subsystem-net|var-lib-docker-overlay2|var-lib-docker-containers|var-lib-kubelet-pods).*
        replacement: $1
        action: drop
```


this is probably not final, we will drop more metrics in more PR