### PR TITLE
reduce-metrics-volume2

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -37,6 +37,8 @@ var (
 
 // Prometheus Kubernetes metrics labels.
 var (
+	// MetricExportedNamespaceLabel is label for filtering by k8s namespace in kube-state-metric.
+	MetricExportedNamespaceLabel = model.LabelName("exported_namespace")
 	// MetricNamespaceLabel is label for filtering by k8s namespace
 	MetricNamespaceLabel = model.LabelName("namespace")
 	// MetricNameLabel is label for filtering by metric name.

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -307,6 +307,14 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				// Add cluster_type label.
 				clusterTypeLabelRelabelConfig,
 			},
+			MetricRelabelConfigs: []*config.RelabelConfig{
+				// keep only kube-system cadvisor metrics
+				{
+					Action:       ActionKeep,
+					SourceLabels: model.LabelNames{MetricExportedNamespaceLabel},
+					Regex:        KubeSystemGiantswarmNSRegexp,
+				},
+			},
 		},
 	}
 

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -463,6 +463,10 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
   - source_labels: []
     target_label: cluster_type
     replacement: guest
+  metric_relabel_configs:
+  - source_labels: [exported_namespace]
+    regex: (kube-system|giantswarm)
+    action: keep
 `,
 		},
 	}

--- a/service/prometheus/scrapeconfig_test_vars.go
+++ b/service/prometheus/scrapeconfig_test_vars.go
@@ -308,6 +308,14 @@ var (
 				Replacement: GuestClusterType,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// keep only kube-system cadvisor metrics
+			{
+				Action:       ActionKeep,
+				SourceLabels: model.LabelNames{MetricExportedNamespaceLabel},
+				Regex:        KubeSystemGiantswarmNSRegexp,
+			},
+		},
 	}
 )
 

--- a/service/resource/configmap/desired_test_vars.go
+++ b/service/resource/configmap/desired_test_vars.go
@@ -310,6 +310,14 @@ var (
 				Replacement: prometheus.GuestClusterType,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// keep only kube-system cadvisor metrics
+			{
+				Action:       prometheus.ActionKeep,
+				SourceLabels: model.LabelNames{prometheus.MetricExportedNamespaceLabel},
+				Regex:        prometheus.KubeSystemGiantswarmNSRegexp,
+			},
+		},
 	}
 )
 


### PR DESCRIPTION
Another round fo removing metrics:
* remove kube-state-metrics from customer namespaces