### PR TITLE
Remove cadvisor container network metrics

### DIFF
--- a/service/prometheus/prometheus.go
+++ b/service/prometheus/prometheus.go
@@ -120,6 +120,9 @@ var (
 	// KubeSystemGiantswarmNSRegexp is the regular expression to match against the kube-system and giantswarm namespace.
 	KubeSystemGiantswarmNSRegexp = config.MustNewRegexp(`(kube-system|giantswarm)`)
 
+	// MetricDropContainerNetworkRegexp is the regular expression to match againts cadvisor container network metrics.
+	MetricDropContainerNetworkRegexp = config.MustNewRegexp(`container_network_.*`)
+
 	// MetricDropFStypeRegexp is the regular expression to match againts not interesting filesystem (for node exporter metrics).
 	MetricDropFStypeRegexp = config.MustNewRegexp(`(cgroup|devpts|mqueue|nsfs|overlay|tmpfs)`)
 

--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -195,6 +195,12 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 					SourceLabels: model.LabelNames{MetricNamespaceLabel},
 					Regex:        KubeSystemGiantswarmNSRegexp,
 				},
+				// drop cadvisor metrics about container network statistics
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel},
+					Regex:        MetricDropContainerNetworkRegexp,
+				},
 			},
 		},
 

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -365,6 +365,9 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
   - source_labels: [namespace]
     regex: (kube-system|giantswarm)
     action: keep
+  - source_labels: [__name__]
+    regex: container_network_.*
+    action: keep
 - job_name: guest-cluster-xa5ly-kubelet
   scheme: https
   kubernetes_sd_configs:

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -367,7 +367,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     action: keep
   - source_labels: [__name__]
     regex: container_network_.*
-    action: keep
+    action: drop
 - job_name: guest-cluster-xa5ly-kubelet
   scheme: https
   kubernetes_sd_configs:

--- a/service/prometheus/scrapeconfig_test_vars.go
+++ b/service/prometheus/scrapeconfig_test_vars.go
@@ -131,6 +131,12 @@ var (
 				SourceLabels: model.LabelNames{MetricNamespaceLabel},
 				Regex:        KubeSystemGiantswarmNSRegexp,
 			},
+			// drop cadvisor metrics about container network statistics
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        MetricDropContainerNetworkRegexp,
+			},
 		},
 	}
 	TestConfigOneKubelet = config.ScrapeConfig{

--- a/service/resource/configmap/desired_test_vars.go
+++ b/service/resource/configmap/desired_test_vars.go
@@ -133,6 +133,12 @@ var (
 				SourceLabels: model.LabelNames{prometheus.MetricNamespaceLabel},
 				Regex:        prometheus.KubeSystemGiantswarmNSRegexp,
 			},
+			// drop cadvisor metrics about container network statistics
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
+				Regex:        prometheus.MetricDropContainerNetworkRegexp,
+			},
 		},
 	}
 	TestConfigOneKubelet = config.ScrapeConfig{


### PR DESCRIPTION
Remove cadvisor container network metrics

we still collect these metrics for `kube-system` and `giantswarm` ns and its still lots of metrics so let's drop it now. It's not very useful and we don't use it ATM. 