### PR TITLE
Fix metrics relabel for node-exporter

### DIFF
--- a/service/prometheus/scrapeconfig.go
+++ b/service/prometheus/scrapeconfig.go
@@ -268,7 +268,7 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 			MetricRelabelConfigs: []*config.RelabelConfig{
 				// Drop many mounts that are not interesting based on fstype.
 				{
-					Action:       ActionKeep,
+					Action:       ActionDrop,
 					SourceLabels: model.LabelNames{MetricFSTypeLabel},
 					Regex:        MetricDropFStypeRegexp,
 				},

--- a/service/prometheus/scrapeconfig_test.go
+++ b/service/prometheus/scrapeconfig_test.go
@@ -435,7 +435,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
   metric_relabel_configs:
   - source_labels: [fstype]
     regex: (cgroup|devpts|mqueue|nsfs|overlay|tmpfs)
-    action: keep
+    action: drop
   - source_labels: [__name__, state]
     regex: node_systemd_unit_state;(active|activating|deactivating|inactive)
     action: drop

--- a/service/prometheus/scrapeconfig_test_vars.go
+++ b/service/prometheus/scrapeconfig_test_vars.go
@@ -253,7 +253,7 @@ var (
 		MetricRelabelConfigs: []*config.RelabelConfig{
 			// Drop many mounts that are not interesting based on fstype.
 			{
-				Action:       ActionKeep,
+				Action:       ActionDrop,
 				SourceLabels: model.LabelNames{MetricFSTypeLabel},
 				Regex:        MetricDropFStypeRegexp,
 			},

--- a/service/resource/configmap/desired_test_vars.go
+++ b/service/resource/configmap/desired_test_vars.go
@@ -255,7 +255,7 @@ var (
 		MetricRelabelConfigs: []*config.RelabelConfig{
 			// Drop many mounts that are not interesting based on fstype.
 			{
-				Action:       prometheus.ActionKeep,
+				Action:       prometheus.ActionDrop,
 				SourceLabels: model.LabelNames{prometheus.MetricFSTypeLabel},
 				Regex:        prometheus.MetricDropFStypeRegexp,
 			},


### PR DESCRIPTION
`action: keep` for mounts was a typo.

This was the reason that we did not have any other metrics (except mounts) for guest clusters from node-exporter.

From [docs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/):

> keep: Drop targets for which regex does not match the concatenated source_labels.