### PR TITLE
Drop unused nginx metrics

### DIFF
--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -139,7 +139,7 @@ var (
 	KubeSystemGiantswarmNSRegexp = config.MustNewRegexp(`(kube-system|giantswarm)`)
 
 	// MetricDropBucketLatencies is the regular expression to match against the several bucket latencies metrics.
-	MetricDropBucketLatencies = config.MustNewRegexp(`(apiserver_admission_controller_admission_latencies_seconds_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)`)
+	MetricDropBucketLatencies = config.MustNewRegexp(`(apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)`)
 
 	// MetricDropContainerNetworkRegexp is the regular expression to match againts cadvisor container network metrics.
 	MetricDropContainerNetworkRegexp = config.MustNewRegexp(`container_network_.*`)

--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -138,8 +138,8 @@ var (
 	// KubeSystemGiantswarmNSRegexp is the regular expression to match against the kube-system and giantswarm namespace.
 	KubeSystemGiantswarmNSRegexp = config.MustNewRegexp(`(kube-system|giantswarm)`)
 
-	// MetricDropApiServerAdmissionController is the regular expression to match against the apiserver_admission_controller_admission_latencies_seconds_bucket metric.
-	MetricDropApiServerAdmissionControllerBucket = config.MustNewRegexp(`apiserver_admission_controller_admission_latencies_seconds_bucket`)
+	// MetricDropBucketLatencies is the regular expression to match against the several bucket latencies metrics.
+	MetricDropBucketLatencies = config.MustNewRegexp(`(apiserver_admission_controller_admission_latencies_seconds_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)`)
 
 	// MetricDropContainerNetworkRegexp is the regular expression to match againts cadvisor container network metrics.
 	MetricDropContainerNetworkRegexp = config.MustNewRegexp(`container_network_.*`)

--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -138,11 +138,17 @@ var (
 	// KubeSystemGiantswarmNSRegexp is the regular expression to match against the kube-system and giantswarm namespace.
 	KubeSystemGiantswarmNSRegexp = config.MustNewRegexp(`(kube-system|giantswarm)`)
 
+	// MetricDropApiServerAdmissionController is the regular expression to match against the apiserver_admission_controller_admission_latencies_seconds_bucket metric.
+	MetricDropApiServerAdmissionControllerBucket = config.MustNewRegexp(`apiserver_admission_controller_admission_latencies_seconds_bucket`)
+
 	// MetricDropContainerNetworkRegexp is the regular expression to match againts cadvisor container network metrics.
 	MetricDropContainerNetworkRegexp = config.MustNewRegexp(`container_network_.*`)
 
 	// MetricDropFStypeRegexp is the regular expression to match againts not interesting filesystem (for node exporter metrics).
 	MetricDropFStypeRegexp = config.MustNewRegexp(`(cgroup|devpts|mqueue|nsfs|overlay|tmpfs)`)
+
+	// MetricDropICRegexp is the regular expression to match against useless metric exposed by IC.
+	MetricDropICRegexp = config.MustNewRegexp(`(ingress_controller_ssl_expire_time_seconds|nginx.*)`)
 
 	// MetricDropSystemdStateRegexp is the regular expression to match againts not interesting systemd unit (for node exporter metrics).
 	MetricDropSystemdStateRegexp = config.MustNewRegexp(`node_systemd_unit_state;(active|activating|deactivating|inactive)`)

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -201,6 +201,14 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				// Add cluster_type label.
 				clusterTypeLabelRelabelConfig,
 			},
+			MetricRelabelConfigs: []*config.RelabelConfig{
+				// drop several bucket latency metric
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel},
+					Regex:        MetricDropBucketLatencies,
+				},
+			},
 		},
 
 		{
@@ -395,12 +403,6 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 					Action:       ActionDrop,
 					SourceLabels: model.LabelNames{MetricNameLabel},
 					Regex:        MetricDropICRegexp,
-				},
-				// drop several bucket latency metric
-				{
-					Action:       ActionDrop,
-					SourceLabels: model.LabelNames{MetricNameLabel},
-					Regex:        MetricDropBucketLatencies,
 				},
 			},
 		},

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -396,11 +396,11 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 					SourceLabels: model.LabelNames{MetricNameLabel},
 					Regex:        MetricDropICRegexp,
 				},
-				// drop APi admission bucket latency metric
+				// drop several bucket latency metric
 				{
 					Action:       ActionDrop,
 					SourceLabels: model.LabelNames{MetricNameLabel},
-					Regex:        MetricDropApiServerAdmissionControllerBucket,
+					Regex:        MetricDropBucketLatencies,
 				},
 			},
 		},

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -390,6 +390,18 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 					SourceLabels: model.LabelNames{MetricExportedNamespaceLabel},
 					Regex:        KubeSystemGiantswarmNSRegexp,
 				},
+				// drop useless IC metrics
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel},
+					Regex:        MetricDropICRegexp,
+				},
+				// drop APi admission bucket latency metric
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel},
+					Regex:        MetricDropApiServerAdmissionControllerBucket,
+				},
 			},
 		},
 	}

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -503,7 +503,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     regex: (ingress_controller_ssl_expire_time_seconds|nginx.*)
     action: drop
   - source_labels: [__name__]
-    regex: apiserver_admission_controller_admission_latencies_seconds_bucket
+    regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
     action: drop
 `,
 		},

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -321,6 +321,10 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     replacement: xa5ly
   - target_label: cluster_type
     replacement: guest
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
+    action: drop
 - job_name: guest-cluster-xa5ly-cadvisor
   scheme: https
   kubernetes_sd_configs:
@@ -501,9 +505,6 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     action: keep
   - source_labels: [__name__]
     regex: (ingress_controller_ssl_expire_time_seconds|nginx.*)
-    action: drop
-  - source_labels: [__name__]
-    regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
     action: drop
 `,
 		},

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -503,7 +503,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     regex: (ingress_controller_ssl_expire_time_seconds|nginx.*)
     action: drop
   - source_labels: [__name__]
-    regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
+    regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
     action: drop
 `,
 		},

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -499,6 +499,12 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
   - source_labels: [exported_namespace]
     regex: (kube-system|giantswarm)
     action: keep
+  - source_labels: [__name__]
+    regex: (ingress_controller_ssl_expire_time_seconds|nginx.*)
+    action: drop
+  - source_labels: [__name__]
+    regex: apiserver_admission_controller_admission_latencies_seconds_bucket
+    action: drop
 `,
 		},
 	}

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -381,6 +381,12 @@ var (
 				SourceLabels: model.LabelNames{MetricNameLabel},
 				Regex:        MetricDropICRegexp,
 			},
+			// drop several bucket latency metric
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        MetricDropBucketLatencies,
+			},
 		},
 	}
 )

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -59,6 +59,14 @@ var (
 				Replacement: GuestClusterType,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// drop several bucket latency metric
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        MetricDropBucketLatencies,
+			},
+		},
 	}
 	TestConfigOneCadvisor = config.ScrapeConfig{
 		JobName: "guest-cluster-xa5ly-cadvisor",
@@ -380,12 +388,6 @@ var (
 				Action:       ActionDrop,
 				SourceLabels: model.LabelNames{MetricNameLabel},
 				Regex:        MetricDropICRegexp,
-			},
-			// drop several bucket latency metric
-			{
-				Action:       ActionDrop,
-				SourceLabels: model.LabelNames{MetricNameLabel},
-				Regex:        MetricDropBucketLatencies,
 			},
 		},
 	}

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -375,6 +375,12 @@ var (
 				SourceLabels: model.LabelNames{MetricExportedNamespaceLabel},
 				Regex:        KubeSystemGiantswarmNSRegexp,
 			},
+			// drop useless IC metrics
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        MetricDropICRegexp,
+			},
 		},
 	}
 )

--- a/service/controller/v1/resource/configmap/desired_test_vars.go
+++ b/service/controller/v1/resource/configmap/desired_test_vars.go
@@ -377,6 +377,18 @@ var (
 				SourceLabels: model.LabelNames{prometheus.MetricExportedNamespaceLabel},
 				Regex:        prometheus.KubeSystemGiantswarmNSRegexp,
 			},
+			// drop useless IC metrics
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
+				Regex:        prometheus.MetricDropICRegexp,
+			},
+			// drop APi admission bucket latency metric
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
+				Regex:        prometheus.MetricDropApiServerAdmissionControllerBucket,
+			},
 		},
 	}
 )

--- a/service/controller/v1/resource/configmap/desired_test_vars.go
+++ b/service/controller/v1/resource/configmap/desired_test_vars.go
@@ -61,6 +61,14 @@ var (
 				Replacement: prometheus.GuestClusterType,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			// drop several bucket latency metric
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
+				Regex:        prometheus.MetricDropBucketLatencies,
+			},
+		},
 	}
 	TestConfigOneCadvisor = config.ScrapeConfig{
 		JobName: "guest-cluster-xa5ly-cadvisor",
@@ -382,12 +390,6 @@ var (
 				Action:       prometheus.ActionDrop,
 				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
 				Regex:        prometheus.MetricDropICRegexp,
-			},
-			// drop several bucket latency metric
-			{
-				Action:       prometheus.ActionDrop,
-				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
-				Regex:        prometheus.MetricDropBucketLatencies,
 			},
 		},
 	}

--- a/service/controller/v1/resource/configmap/desired_test_vars.go
+++ b/service/controller/v1/resource/configmap/desired_test_vars.go
@@ -383,11 +383,11 @@ var (
 				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
 				Regex:        prometheus.MetricDropICRegexp,
 			},
-			// drop APi admission bucket latency metric
+			// drop several bucket latency metric
 			{
 				Action:       prometheus.ActionDrop,
 				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
-				Regex:        prometheus.MetricDropApiServerAdmissionControllerBucket,
+				Regex:        prometheus.MetricDropBucketLatencies,
 			},
 		},
 	}


### PR DESCRIPTION
drop metrics related to IC controller for guest clusters (we only leave few important)
drop some bucket latency metrics that we don't use anywhere

on Asgard this is more than 100 000 metrics


towards https://github.com/giantswarm/giantswarm/issues/4127