### PR TITLE
scrape cadvisor metrics from kubelet

### DIFF
--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -114,7 +114,7 @@ const (
 // Path replacements.
 const (
 	// CadvisorMetricsPath is the path under which cadvisor metrics can be scraped.
-	CadvisorMetricsPath = "/api/v1/nodes/${1}:4194/proxy/metrics"
+	CadvisorMetricsPath = "/api/v1/nodes/${1}:10250/proxy/metrics/cadvisor"
 
 	// NodeExporterPort is the path under which node-exporter metrics can be scraped.
 	NodeExporterPort = "${1}:10300"

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -347,7 +347,7 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     replacement: apiserver.xa5ly
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:4194/proxy/metrics
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   - target_label: cluster_id


### PR DESCRIPTION
* in 1.10 the cadvisor port was deprecated
* in 1.11 the cadvisor port was turned off by default.
* in 1.12 it was removed. 

imo we should be good to scrape the cadvisor metrics from the kubelet port in all clusters.