### PR TITLE
excludes deleted services from being considered for target generation

### DIFF
--- a/service/controller/v1/prometheus/filter.go
+++ b/service/controller/v1/prometheus/filter.go
@@ -10,8 +10,18 @@ func FilterInvalidServices(services []v1.Service) []v1.Service {
 	filteredServices := []v1.Service{}
 
 	for _, service := range services {
-		if _, ok := service.ObjectMeta.Annotations[ClusterAnnotation]; !ok {
-			continue
+		{
+			isDeleted := service.GetDeletionTimestamp() != nil
+			if isDeleted {
+				continue
+			}
+		}
+
+		{
+			_, hasAnnotation := service.ObjectMeta.Annotations[ClusterAnnotation]
+			if !hasAnnotation {
+				continue
+			}
 		}
 
 		filteredServices = append(filteredServices, service)


### PR DESCRIPTION
We still seem to have issues with deleted clusters paging on KVM. There is an [exception implemented in the `kvm-operator`](https://github.com/giantswarm/kvm-operator/blob/99142dd3984328fb0d1b15750f2cea553a1137ff/service/controller/v16/resource/service/current.go#L48-L69). I am wondering if we could just drop that since other providers should have the same problem. Maybe? Uncertain. Anyway, I think it is safe to exclude deleted services from the target generation here. 