### PR TITLE
Use proper API to fetch live prometheus config

### DIFF
--- a/service/controller/v1/prometheus/service_test.go
+++ b/service/controller/v1/prometheus/service_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -245,8 +245,8 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == prometheusConfigPath {
-					io.WriteString(w, "<html><pre>foobar</pre></html>")
+				if r.URL.Path == ConfigPath {
+					io.WriteString(w, "{ \"status\": \"success\", \"data\": { \"yaml\": \"foobar\" }}")
 					return
 				}
 				t.Fatalf("unexpected http request, reload is not required")
@@ -268,11 +268,11 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == prometheusConfigPath {
-					io.WriteString(w, "<html><pre>foo</pre></html>")
+				if r.URL.Path == ConfigPath {
+					io.WriteString(w, "{ \"status\": \"success\", \"data\": { \"yaml\": \"foo\" }}")
 					return
 				}
-				if r.URL.Path != prometheusReloadPath {
+				if r.URL.Path != ReloadPath {
 					t.Fatalf("unexpected http request, reload is required")
 				}
 			},
@@ -292,7 +292,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == prometheusConfigPath {
+				if r.URL.Path == ConfigPath {
 					http.Error(w, fmt.Sprintf("error getting prometheus config"), http.StatusInternalServerError)
 					return
 				}
@@ -314,7 +314,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == prometheusConfigPath {
+				if r.URL.Path == ConfigPath {
 					io.WriteString(w, "lwnefknfiefnpeijfpqofjqpwofjqpwofjqpwofjpofjwpofjwpeofj")
 					return
 				}
@@ -335,7 +335,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == prometheusConfigPath {
+				if r.URL.Path == ConfigPath {
 					io.WriteString(w, "")
 					return
 				}
@@ -356,11 +356,11 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == prometheusConfigPath {
+				if r.URL.Path == ConfigPath {
 					io.WriteString(w, "<html><pre>foo</pre></html>")
 					return
 				}
-				if r.URL.Path == prometheusReloadPath {
+				if r.URL.Path == ReloadPath {
 					http.Error(w, fmt.Sprintf("error reloading prometheus"), http.StatusInternalServerError)
 					return
 				}

--- a/service/controller/v1/prometheus/spec.go
+++ b/service/controller/v1/prometheus/spec.go
@@ -1,12 +1,12 @@
 package prometheus
 
 const (
-	// prometheusConfigPath is the Prometheus route that returns the current
-	// configuration webpage.
-	prometheusConfigPath = "/config"
-	// prometheusReloadPath is the Prometheus API route that reloads the configuration
+	// ConfigPath is the Prometheus route that returns the current
+	// configuration.
+	ConfigPath = "/api/v1/status/config"
+	// ReloadPath is the Prometheus API route that reloads the configuration
 	// when POSTed to.
-	prometheusReloadPath = "/-/reload"
+	ReloadPath = "/-/reload"
 )
 
 // PrometheusReloader represents a service that can reload Prometheus configuration.

--- a/service/controller/v1/resource/configmap/update_test.go
+++ b/service/controller/v1/resource/configmap/update_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/giantswarm/micrologger/microloggertest"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
@@ -451,13 +451,13 @@ func Test_Resource_ConfigMap_Reload(t *testing.T) {
 	reloadRequestCount := 0
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/config" {
+		if r.URL.Path == prometheus.ConfigPath {
 			configRequestCount++
 
-			io.WriteString(w, "<html><pre>foo</pre></html>")
+			io.WriteString(w, "{ \"status\": \"success\", \"data\": { \"yaml\": \"foo\" }}")
 			return
 		}
-		if r.URL.Path == "/-/reload" {
+		if r.URL.Path == prometheus.ReloadPath {
 			receivedReloadMessage = r
 			reloadRequestCount++
 


### PR DESCRIPTION
Earlier implementation parsed an HTML page containing live prometheus config
but that broke when the HTML got changed upstream. There's an actual
programmatic API to fetch live config so use that.

Documentation: https://prometheus.io/docs/prometheus/latest/querying/api/#config