### PR TITLE
Remove reflector metrics from kubelet job

### DIFF
--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -150,11 +150,14 @@ var (
 	// MetricDropICRegexp is the regular expression to match against useless metric exposed by IC.
 	MetricDropICRegexp = config.MustNewRegexp(`(ingress_controller_ssl_expire_time_seconds|nginx.*)`)
 
-	// MetricDropSystemdStateRegexp is the regular expression to match againts not interesting systemd unit (for node exporter metrics).
+	// MetricDropSystemdStateRegexp is the regular expression to match against not interesting systemd unit (for node exporter metrics).
 	MetricDropSystemdStateRegexp = config.MustNewRegexp(`node_systemd_unit_state;(active|activating|deactivating|inactive)`)
 
 	// MetricDropSystemdNameRegexp is the regular expression to match against not interesting systemd units(docker mounts and calico network devices).
 	MetricDropSystemdNameRegexp = config.MustNewRegexp(`node_systemd_unit_state;(dev-disk-by|run-docker-netns|sys-devices|sys-subsystem-net|var-lib-docker-overlay2|var-lib-docker-containers|var-lib-kubelet-pods).*`)
+
+	// MetricsDropReflectorRegexp is the regular expression to match against spammy reflector metrics returned by the Kubelet.
+	MetricsDropReflectorRegexp = config.MustNewRegexp(`(reflector.*)`)
 
 	// NginxIngressControllerPodNameRegexp is the regular expression to match nginx ic pod name.
 	NginxIngressControllerPodNameRegexp = config.MustNewRegexp(`(nginx-ingress-controller.*)`)

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -129,6 +129,11 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 		TargetLabel: ClusterTypeLabel,
 		Replacement: GuestClusterType,
 	}
+	reflectorRelabelConfig := &config.RelabelConfig{
+		Action:       ActionDrop,
+		SourceLabels: model.LabelNames{MetricNameLabel},
+		Regex:        MetricsDropReflectorRegexp,
+	}
 	rewriteAddress := &config.RelabelConfig{
 		TargetLabel: AddressLabel,
 		Replacement: key.APIServiceHost(key.PrefixMaster, clusterID),
@@ -289,6 +294,9 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				// Add role label.
 				roleLabelRelabelConfig,
 				missingRoleLabelRelabelConfig,
+			},
+			MetricRelabelConfigs: []*config.RelabelConfig{
+				reflectorRelabelConfig,
 			},
 		},
 

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -401,6 +401,10 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     regex: null
     target_label: role
     replacement: worker
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: (reflector.*)
+    action: drop
 - job_name: guest-cluster-xa5ly-node-exporter
   scheme: http
   kubernetes_sd_configs:

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -210,6 +210,13 @@ var (
 				TargetLabel:  RoleLabel,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        MetricsDropReflectorRegexp,
+			},
+		},
 	}
 	TestConfigOneNodeExporter = config.ScrapeConfig{
 		JobName: "guest-cluster-xa5ly-node-exporter",

--- a/service/controller/v1/resource/configmap/desired_test_vars.go
+++ b/service/controller/v1/resource/configmap/desired_test_vars.go
@@ -206,6 +206,13 @@ var (
 				TargetLabel:  prometheus.RoleLabel,
 			},
 		},
+		MetricRelabelConfigs: []*config.RelabelConfig{
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
+				Regex:        prometheus.MetricsDropReflectorRegexp,
+			},
+		},
 	}
 	TestConfigOneNodeExporter = config.ScrapeConfig{
 		JobName: "guest-cluster-xa5ly-node-exporter",


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5174

The kubelets in newer Kubernetes versions spit out a fucking ton of reflector metrics (around 1 million per tenant cluster), which just blows the whole monitoring stack (high number of time series leads to high memory usage) for newer tenant clusters.

So, we now drop any metrics prefixed with `reflector` from kubelet scraping, which drastically reduces the number of time series in Prometheus to healthy levels (e.g: from 5m to 700k)