### PR TITLE
move drop reflector config to relabel_configs

### DIFF
--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -300,8 +300,6 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				// Add role label.
 				roleLabelRelabelConfig,
 				missingRoleLabelRelabelConfig,
-			},
-			MetricRelabelConfigs: []*config.RelabelConfig{
 				reflectorRelabelConfig,
 			},
 		},

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -401,7 +401,6 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
     regex: null
     target_label: role
     replacement: worker
-  metric_relabel_configs:
   - source_labels: [__name__]
     regex: (reflector.*)
     action: drop

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -209,8 +209,6 @@ var (
 				Replacement:  WorkerRole,
 				TargetLabel:  RoleLabel,
 			},
-		},
-		MetricRelabelConfigs: []*config.RelabelConfig{
 			{
 				Action:       ActionDrop,
 				SourceLabels: model.LabelNames{MetricNameLabel},

--- a/service/controller/v1/resource/configmap/desired_test_vars.go
+++ b/service/controller/v1/resource/configmap/desired_test_vars.go
@@ -205,8 +205,6 @@ var (
 				Replacement:  prometheus.WorkerRole,
 				TargetLabel:  prometheus.RoleLabel,
 			},
-		},
-		MetricRelabelConfigs: []*config.RelabelConfig{
 			{
 				Action:       prometheus.ActionDrop,
 				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5520

Attempt at fixing Prometheus OOM issues.

There is a previous[PR](https://github.com/giantswarm/prometheus-config-controller/pull/103) which attempted to fix this by not ignoring `reflector*` metrics on scrape.

But it seems that `metric_relabel_configs` is applied after scrape happened and before storing into database, whereas `relabel_config` is applied before scrape. So this PR moves the "drop reflector*" to `relabel_config`.

After testing, `reflector*` metrics are still present in the database. So this is not correct and need to be adjusted.