### PR TITLE
drop reflector metrics from apiserver jobs

### DIFF
--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -229,6 +229,7 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 					SourceLabels: model.LabelNames{MetricNameLabel},
 					Regex:        MetricDropBucketLatencies,
 				},
+				reflectorRelabelConfig,
 			},
 		},
 

--- a/service/controller/v1/prometheus/scrapeconfig_test.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test.go
@@ -325,6 +325,9 @@ func Test_Prometheus_YamlMarshal(t *testing.T) {
   - source_labels: [__name__]
     regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
     action: drop
+  - source_labels: [__name__]
+    regex: (reflector.*)
+    action: drop
 - job_name: guest-cluster-xa5ly-cadvisor
   scheme: https
   kubernetes_sd_configs:

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -68,6 +68,11 @@ var (
 				SourceLabels: model.LabelNames{MetricNameLabel},
 				Regex:        MetricDropBucketLatencies,
 			},
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        MetricsDropReflectorRegexp,
+			},
 		},
 	}
 	TestConfigOneCadvisor = config.ScrapeConfig{

--- a/service/controller/v1/resource/configmap/desired_test_vars.go
+++ b/service/controller/v1/resource/configmap/desired_test_vars.go
@@ -68,6 +68,11 @@ var (
 				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
 				Regex:        prometheus.MetricDropBucketLatencies,
 			},
+			{
+				Action:       prometheus.ActionDrop,
+				SourceLabels: model.LabelNames{prometheus.MetricNameLabel},
+				Regex:        prometheus.MetricsDropReflectorRegexp,
+			},
 		},
 	}
 	TestConfigOneCadvisor = config.ScrapeConfig{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/5520

We [previously](https://github.com/giantswarm/prometheus-config-controller/pull/103) found out that reflector metrics because of their very high number were the biggest pain point in Prometheus OOM issue. We already removed them from kubelet jobs, but there are some more exposed by the apiserver also.

This PR drop the reflector metrics exposed by apiserver jobs.

<img width="1258" alt="Screenshot 2019-03-21 at 11 09 49" src="https://user-images.githubusercontent.com/6536819/54746508-9cf19380-4bcc-11e9-8b3a-84bec226a9c7.png">
