### PR TITLE
controller: revert "reconcile every minute always"

### DIFF
--- a/service/controller/prometheus.go
+++ b/service/controller/prometheus.go
@@ -10,7 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
-	v1 "github.com/giantswarm/prometheus-config-controller/service/controller/v1"
+	"github.com/giantswarm/prometheus-config-controller/service/controller/v1"
 )
 
 type PrometheusConfig struct {
@@ -45,10 +45,10 @@ func NewPrometheus(config PrometheusConfig) (*Prometheus, error) {
 	{
 		c := informer.Config{
 			Logger:  config.Logger,
-			Watcher: config.K8sClient.CoreV1().Pods("monitoring"),
+			Watcher: config.K8sClient.CoreV1().Services(""),
 
 			ListOptions: metav1.ListOptions{
-				LabelSelector: "app=prometheus",
+				LabelSelector: "giantswarm.io/cluster",
 			},
 			RateWait:     informer.DefaultRateWait,
 			ResyncPeriod: config.ResyncPeriod,


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/5658.

Reopened https://github.com/giantswarm/giantswarm/issues/5301.

This reverts commit 081a5bd7494ff45c22e2034e1c950c133998d2e3.

The previous change brings more charm than good. I need to debug
further.

> `prometheus-config-controller` watches pod it is running in
> (https://github.com/giantswarm/prometheus-config-controller/pull/110).
> This means it sets the finalizer on its own pod. When `g8s-prometheus`
> is deployed too often we can run into a deadlock. There may be
> situations there are no nodes with sufficient resources / fulfilling
> the anti-affinity criteria, new pod can't be scheduled and there is no
> `prometheus-config-controller` running to observe deleted pod and
> remove the finalizer. The solution for that is to remove
> `operatorkit.giantswarm.io/prometheus-config-controller` manually from
> terminating prometheus pod.