### PR TITLE
configmap, prometheus: return reloadThrottleError and keep finalizers

### DIFF
--- a/service/controller/v1/key/key.go
+++ b/service/controller/v1/key/key.go
@@ -3,6 +3,7 @@ package key
 import (
 	"fmt"
 	"path"
+	"strings"
 )
 
 const (
@@ -52,4 +53,18 @@ func APIProxyPodMetricsPath(namespace, port string) string {
 
 func APIServiceHost(prefix string, clusterID string) string {
 	return fmt.Sprintf("%s.%s:443", prefix, clusterID)
+}
+
+// PrometheusURLConfig returns the Prometheus API URL that returns the current
+// configuration. It assumes that address is a valid HTTP URL.
+func PrometheusURLConfig(address string) string {
+	u := strings.TrimSuffix(address, "/")
+	return u + "/api/v1/status/config"
+}
+
+// PrometheusURLReload returns the Prometheus API URL that reloads the
+// configuration. It assumes that address is a valid HTTP URL.
+func PrometheusURLReload(address string) string {
+	u := strings.TrimSuffix(address, "/")
+	return u + "/-/reload"
 }

--- a/service/controller/v1/prometheus/service_test.go
+++ b/service/controller/v1/prometheus/service_test.go
@@ -246,7 +246,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == ConfigPath {
+				if r.URL.Path == "/api/v1/status/config" {
 					io.WriteString(w, "{ \"status\": \"success\", \"data\": { \"yaml\": \"foobar\" }}")
 					return
 				}
@@ -269,11 +269,11 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == ConfigPath {
+				if r.URL.Path == "/api/v1/status/config" {
 					io.WriteString(w, "{ \"status\": \"success\", \"data\": { \"yaml\": \"foo\" }}")
 					return
 				}
-				if r.URL.Path != ReloadPath {
+				if r.URL.Path != "/-/reload" {
 					t.Fatalf("unexpected http request, reload is required")
 				}
 			},
@@ -293,7 +293,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == ConfigPath {
+				if r.URL.Path == "/api/v1/status/config" {
 					http.Error(w, fmt.Sprintf("error getting prometheus config"), http.StatusInternalServerError)
 					return
 				}
@@ -315,7 +315,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == ConfigPath {
+				if r.URL.Path == "/api/v1/status/config" {
 					io.WriteString(w, "lwnefknfiefnpeijfpqofjqpwofjqpwofjqpwofjpofjwpofjwpeofj")
 					return
 				}
@@ -336,7 +336,7 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == ConfigPath {
+				if r.URL.Path == "/api/v1/status/config" {
 					io.WriteString(w, "")
 					return
 				}
@@ -357,11 +357,11 @@ func Test_Prometheus_Reload(t *testing.T) {
 				},
 			},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				if r.URL.Path == ConfigPath {
+				if r.URL.Path == "/api/v1/status/config" {
 					io.WriteString(w, "<html><pre>foo</pre></html>")
 					return
 				}
-				if r.URL.Path == ReloadPath {
+				if r.URL.Path == "/-/reload" {
 					http.Error(w, fmt.Sprintf("error reloading prometheus"), http.StatusInternalServerError)
 					return
 				}

--- a/service/controller/v1/prometheus/spec.go
+++ b/service/controller/v1/prometheus/spec.go
@@ -2,15 +2,6 @@ package prometheus
 
 import "context"
 
-const (
-	// ConfigPath is the Prometheus route that returns the current
-	// configuration.
-	ConfigPath = "/api/v1/status/config"
-	// ReloadPath is the Prometheus API route that reloads the configuration
-	// when POSTed to.
-	ReloadPath = "/-/reload"
-)
-
 // PrometheusReloader represents a service that can reload Prometheus configuration.
 type PrometheusReloader interface {
 	// Reload should reload the Prometheus configuration, possibly taking

--- a/service/controller/v1/resource/configmap/update_test.go
+++ b/service/controller/v1/resource/configmap/update_test.go
@@ -451,13 +451,13 @@ func Test_Resource_ConfigMap_Reload(t *testing.T) {
 	reloadRequestCount := 0
 
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == prometheus.ConfigPath {
+		if r.URL.Path == "/api/v1/status/config" {
 			configRequestCount++
 
 			io.WriteString(w, "{ \"status\": \"success\", \"data\": { \"yaml\": \"foo\" }}")
 			return
 		}
-		if r.URL.Path == prometheus.ReloadPath {
+		if r.URL.Path == "/-/reload" {
 			receivedReloadMessage = r
 			reloadRequestCount++
 

--- a/service/error.go
+++ b/service/error.go
@@ -12,3 +12,12 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
+
+var waitError = &microerror.Error{
+	Kind: "waitError",
+}
+
+// IsWait asserts waitError.
+func IsWait(err error) bool {
+	return microerror.Cause(err) == waitError
+}

--- a/service/service.go
+++ b/service/service.go
@@ -2,8 +2,12 @@ package service
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"sync"
+	"time"
 
+	"github.com/giantswarm/backoff"
 	"github.com/giantswarm/microendpoint/service/version"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,6 +18,7 @@ import (
 
 	"github.com/giantswarm/prometheus-config-controller/flag"
 	"github.com/giantswarm/prometheus-config-controller/service/controller"
+	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/key"
 	"github.com/giantswarm/prometheus-config-controller/service/healthz"
 )
 
@@ -32,7 +37,10 @@ type Service struct {
 	Healthz *healthz.Service
 	Version *version.Service
 
+	logger micrologger.Logger
+
 	bootOnce             sync.Once
+	prometheusAddress    string
 	prometheusController *controller.Prometheus
 }
 
@@ -130,7 +138,11 @@ func New(config Config) (*Service, error) {
 		Healthz: healthzService,
 		Version: versionService,
 
-		bootOnce:             sync.Once{},
+		logger: config.Logger,
+
+		bootOnce: sync.Once{},
+
+		prometheusAddress:    config.Viper.GetString(config.Flag.Service.Prometheus.Address),
 		prometheusController: prometheusController,
 	}
 
@@ -138,7 +150,53 @@ func New(config Config) (*Service, error) {
 }
 
 func (s *Service) Boot() {
+	ctx := context.TODO()
+
+	err := s.boot(ctx)
+	if err != nil {
+		s.logger.LogCtx(ctx, "level", "error", "message", "failed to boot the service", "stack", fmt.Sprintf("%#v", err))
+		panic(fmt.Sprintf("failed to boot the service, please see the logs"))
+	}
+}
+
+func (s *Service) boot(ctx context.Context) error {
+	// Wait for Prometheus to be ready before booting the controller.
+	// Otherwise it will fail to (re)load the configuration.
+	{
+		s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waiting for Prometheus to be up"))
+
+		url := key.PrometheusURLConfig(s.prometheusAddress)
+
+		o := func() error {
+			res, err := http.Get(url)
+			if err != nil {
+				return microerror.Maskf(waitError, "failed request URL %#q with error %#q", url, err)
+			}
+
+			if res.StatusCode < 200 || res.StatusCode > 299 {
+				return microerror.Maskf(waitError, "expected 2xx response for URL %#q but got %d", url, res.StatusCode)
+			}
+
+			return nil
+		}
+		b := backoff.NewMaxRetries(10, 60*time.Second)
+		n := backoff.NewNotifier(s.logger, ctx)
+
+		// Prometheus won't start in 90 seconds anyway so let's not
+		// spam with logs and wait for it.
+		time.Sleep(90 * time.Second)
+
+		err := backoff.RetryNotify(o, b, n)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		s.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("waited for Prometheus to be up"))
+	}
+
 	s.bootOnce.Do(func() {
-		go s.prometheusController.Boot(context.Background())
+		go s.prometheusController.Boot(ctx)
 	})
+
+	return nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/5301

There is a chance that during deleting last cluster the reload request
is throttled, the last Service is removed and the configuration is never
reloaded. Therefore finalizers are kept till the Prometheus
configuration isn't really reloaded.

Note this probably won't solve the PM as we observe that the ConfigMap
doesn't change.

# Requesting a pull to giantswarm:master from giantswarm:prometheus
#
# Write a message for this pull request. The first block
# of text is the title and the rest is the description.