### PR TITLE
patch service finalizers

### DIFF
--- a/service/controller/v1/resource/patchfinalizer/create.go
+++ b/service/controller/v1/resource/patchfinalizer/create.go
@@ -25,7 +25,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		for _, s := range list.Items {
-			if !hasLabel(s.Labels) {
+			if hasLabel(s.Labels) {
 				continue
 			}
 

--- a/service/controller/v1/resource/patchfinalizer/create.go
+++ b/service/controller/v1/resource/patchfinalizer/create.go
@@ -1,0 +1,92 @@
+package patchfinalizer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	finalizerPCC = "operatorkit.giantswarm.io/prometheus-config-controller"
+	labelCluster = "giantswarm.io/cluster"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	var services []corev1.Service
+	{
+		r.logger.LogCtx(ctx, "level", "debug", "message", "finding services to patch")
+
+		list, err := r.k8sClient.CoreV1().Services(corev1.NamespaceAll).List(metav1.ListOptions{})
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		for _, s := range list.Items {
+			if !hasLabel(s.Labels) {
+				continue
+			}
+
+			if !hasFinalizer(s.Finalizers) {
+				continue
+			}
+
+			services = append(services, s)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("found %d services to patch", len(services)))
+	}
+
+	{
+		for _, s := range services {
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("patching service %q in namespace %q", s.Name, s.Namespace))
+
+			s.Finalizers = withoutFinalizer(s.Finalizers)
+
+			_, err := r.k8sClient.CoreV1().Services(s.Namespace).Update(&s)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			r.logger.LogCtx(ctx, "level", "debug", "message", fmt.Sprintf("patched service %q in namespace %q", s.Name, s.Namespace))
+		}
+	}
+
+	return nil
+}
+
+func hasFinalizer(finalizers []string) bool {
+	for _, f := range finalizers {
+		if f == finalizerPCC {
+			return true
+		}
+	}
+
+	return false
+}
+
+func hasLabel(labels map[string]string) bool {
+	for _, l := range labels {
+		if l == labelCluster {
+			return true
+		}
+	}
+
+	return false
+}
+
+func withoutFinalizer(finalizers []string) []string {
+	var list []string
+
+	for _, f := range finalizers {
+		if f == finalizerPCC {
+			continue
+		}
+
+		list = append(list, f)
+	}
+
+	return list
+}

--- a/service/controller/v1/resource/patchfinalizer/delete.go
+++ b/service/controller/v1/resource/patchfinalizer/delete.go
@@ -1,0 +1,9 @@
+package patchfinalizer
+
+import (
+	"context"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/v1/resource/patchfinalizer/error.go
+++ b/service/controller/v1/resource/patchfinalizer/error.go
@@ -1,0 +1,14 @@
+package patchfinalizer
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/v1/resource/patchfinalizer/resource.go
+++ b/service/controller/v1/resource/patchfinalizer/resource.go
@@ -1,0 +1,41 @@
+package patchfinalizer
+
+import (
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"k8s.io/client-go/kubernetes"
+)
+
+const (
+	Name = "patchfinalizerv1"
+)
+
+type Config struct {
+	K8sClient kubernetes.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	k8sClient kubernetes.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/v1/resource_set.go
+++ b/service/controller/v1/resource_set.go
@@ -15,6 +15,7 @@ import (
 	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/prometheus"
 	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/resource/certificate"
 	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/resource/configmap"
+	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/resource/patchfinalizer"
 )
 
 type ResourceSetConfig struct {
@@ -104,9 +105,23 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var patchFinalizerResource controller.Resource
+	{
+		c := patchfinalizer.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		patchFinalizerResource, err = patchfinalizer.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []controller.Resource{
 		certificateResource,
 		configMapResource,
+		patchFinalizerResource,
 	}
 
 	{

--- a/service/controller/v1/resource_set.go
+++ b/service/controller/v1/resource_set.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -116,12 +117,16 @@ func NewResourceSet(config ResourceSetConfig) (*controller.ResourceSet, error) {
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
+
+		err := patchFinalizerResource.EnsureCreated(context.Background(), nil)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
 	}
 
 	resources := []controller.Resource{
 		certificateResource,
 		configMapResource,
-		patchFinalizerResource,
 	}
 
 	{


### PR DESCRIPTION
While working on https://github.com/giantswarm/giantswarm/issues/6028 I noticed that the finalizers are fucked up on some services on the CP. At some point we changed the watch in here and did not clean up afterwards. The patch resource introduced here should just run once and then be dropped again. I will test this. 