### PR TITLE
extend resync period to 3 minutes for more head room

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,7 +139,7 @@ func mainError() error {
 
 	daemonCommand.PersistentFlags().Duration(f.Service.Controller.ControllerBackOffDuration, time.Minute*5, "Maximum backoff duration for controller.")
 	daemonCommand.PersistentFlags().Duration(f.Service.Controller.FrameworkBackOffDuration, time.Minute*5, "Maximum backoff duration for operator framework.")
-	daemonCommand.PersistentFlags().Duration(f.Service.Controller.ResyncPeriod, time.Minute*1, "Controller resync period.")
+	daemonCommand.PersistentFlags().Duration(f.Service.Controller.ResyncPeriod, time.Minute*3, "Controller resync period.")
 
 	newCommand.CobraCommand().Execute()
 


### PR DESCRIPTION
We see errors where the Controller fails to request Prometheus and one reason could be that we press too hard against it. To prevent such situations we simply extend the resync period. 

> {"caller":"github.com/giantswarm/prometheus-config-controller/service/controller/v1/resource/configmap/update.go:97","controller":"prometheus-config-controller","event":"update","function":"ApplyUpdateChange","level":"debug","loop":"135","message":"1m54.139539786s since last reload, minimum time between is 2m0s: reload throttle error","object":"/api/v1/namespaces/du84k/services/master","resource":"configmapv1","time":"2019-09-03T08:12:28.993362+00:00","version":"151036585"}