### PR TITLE
Extends api server metric drop regexp

### DIFF
--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -163,7 +163,7 @@ var (
 	NSRegexp = config.MustNewRegexp(`(kube-system|giantswarm.*|vault-exporter)`)
 
 	// MetricDropBucketLatencies is the regular expression to match against the several bucket latencies metrics.
-	MetricDropBucketLatencies = config.MustNewRegexp(`(apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)`)
+	MetricDropBucketLatencies = config.MustNewRegexp(`(apiserver_admission_controller_admission_latencies_seconds_.*|apiserver_admission_step_admission_latencies_seconds_.*|apiserver_request_count|apiserver_request_duration_seconds_.*|apiserver_request_latencies_.*|apiserver_request_total|apiserver_response_sizes_.*|rest_client_request_latency_seconds_.*)`)
 
 	// MetricDropContainerNetworkRegexp is the regular expression to match againts cadvisor container network metrics.
 	MetricDropContainerNetworkRegexp = config.MustNewRegexp(`container_network_.*`)

--- a/service/controller/v1/prometheus/testdata/scrapeconfig.golden
+++ b/service/controller/v1/prometheus/testdata/scrapeconfig.golden
@@ -27,7 +27,7 @@
     replacement: guest
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (apiserver_admission_controller_admission_latencies_seconds_bucket|apiserver_admission_step_admission_latencies_seconds_bucket|apiserver_response_sizes_bucket|rest_client_request_latency_seconds_bucket|rest_client_request_latency_seconds_bucket)
+    regex: (apiserver_admission_controller_admission_latencies_seconds_.*|apiserver_admission_step_admission_latencies_seconds_.*|apiserver_request_count|apiserver_request_duration_seconds_.*|apiserver_request_latencies_.*|apiserver_request_total|apiserver_response_sizes_.*|rest_client_request_latency_seconds_.*)
     action: drop
   - source_labels: [__name__]
     regex: (reflector.*)


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/7389

Before, on `viking`: 1,466,507 total time series
After:  1,077,242, 36% reduction