### PR TITLE
Revert "configmap, prometheus: update ConfigMap when the last cluster…

### DIFF
--- a/service/controller/v1/prometheus/error.go
+++ b/service/controller/v1/prometheus/error.go
@@ -21,12 +21,3 @@ var invalidConfigError = &microerror.Error{
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
 }
-
-var reloadThrottleError = &microerror.Error{
-	Kind: "reloadThrottleError",
-}
-
-// IsReloadThrottle asserts reloadThrottleError.
-func IsReloadThrottle(err error) bool {
-	return microerror.Cause(err) == reloadThrottleError
-}

--- a/service/controller/v1/prometheus/service.go
+++ b/service/controller/v1/prometheus/service.go
@@ -107,11 +107,6 @@ func New(config Config) (*Service, error) {
 }
 
 func (s *Service) Reload(ctx context.Context) error {
-	err := s.throttleReload(ctx)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	reloadRequired, err := s.isReloadRequired(ctx)
 	if err != nil {
 		return microerror.Mask(err)
@@ -194,10 +189,27 @@ func (s *Service) getConfigFromPrometheus(ctx context.Context) (string, error) {
 	return config, nil
 }
 
+func (s *Service) isReloadRateLimited(ctx context.Context) bool {
+	timeSinceLastReload := time.Since(s.lastReloadTime)
+
+	if timeSinceLastReload < s.minimumReloadTime {
+		s.logger.LogCtx(ctx, "debug", fmt.Sprintf("ignoring reload request, only %s since last reload, minimum time between is %s", timeSinceLastReload, s.minimumReloadTime))
+		configurationReloadIgnoredCount.Inc()
+
+		return true
+	}
+
+	return false
+}
+
 func (s *Service) isReloadRequired(ctx context.Context) (bool, error) {
 	s.logger.LogCtx(ctx, "debug", "checking if reload is required")
 
 	configurationReloadCheckCount.Inc()
+
+	if s.isReloadRateLimited(ctx) {
+		return false, nil
+	}
 
 	s.isReloadRequestedMutex.Lock()
 	isReloadRequested := s.isReloadRequested
@@ -250,18 +262,6 @@ func (s *Service) reload(ctx context.Context) error {
 	configurationReloadCount.Inc()
 
 	s.lastReloadTime = time.Now()
-
-	return nil
-}
-
-func (s *Service) throttleReload(ctx context.Context) error {
-	timeSinceLastReload := time.Since(s.lastReloadTime)
-
-	if timeSinceLastReload < s.minimumReloadTime {
-		configurationReloadIgnoredCount.Inc()
-
-		return microerror.Maskf(reloadThrottleError, "%s since last reload, minimum time between is %s", timeSinceLastReload, s.minimumReloadTime)
-	}
 
 	return nil
 }

--- a/service/controller/v1/resource/configmap/delete.go
+++ b/service/controller/v1/resource/configmap/delete.go
@@ -3,30 +3,16 @@ package configmap
 import (
 	"context"
 
-	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/resource/crud"
 )
 
-// NewDeletePatch calls NewUpdatePatch as the ConfigMap must be updated with
-// removed cluster. This is important when the last cluster in the
-// installation is removed.
+// NewDeletePatch is a no-op.
+// We do not want to delete the configmap, as the running prometheus relies on it.
 func (r *Resource) NewDeletePatch(ctx context.Context, obj, currentState, desiredState interface{}) (*crud.Patch, error) {
-	p, err := r.NewUpdatePatch(ctx, obj, currentState, desiredState)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	return p, nil
+	return nil, nil
 }
 
-// ApplyDeleteChange calls ApplyUpdateChange as the ConfigMap must be updated
-// with removed cluster. This is important when the last cluster in the
-// installation is removed.
+// ApplyDeleteChange is a no-op.
 func (r *Resource) ApplyDeleteChange(ctx context.Context, obj, deleteChange interface{}) error {
-	err := r.ApplyUpdateChange(ctx, obj, deleteChange)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
 	return nil
 }

--- a/service/controller/v1/resource/configmap/delete_test.go
+++ b/service/controller/v1/resource/configmap/delete_test.go
@@ -1,0 +1,67 @@
+package configmap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/giantswarm/micrologger/microloggertest"
+	"k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/prometheus/prometheustest"
+)
+
+// Test_Resource_ConfigMap_NewDeletePatch tests the NewDeletePatch method.
+func Test_Resource_ConfigMap_NewDeletePatch(t *testing.T) {
+	fakeK8sClient := fake.NewSimpleClientset()
+
+	resourceConfig := Config{}
+
+	resourceConfig.K8sClient = fakeK8sClient
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
+
+	resourceConfig.CertDirectory = "/certs"
+	resourceConfig.ConfigMapKey = "prometheus.yml"
+	resourceConfig.ConfigMapName = "prometheus"
+	resourceConfig.ConfigMapNamespace = "monitoring"
+
+	resource, err := New(resourceConfig)
+	if err != nil {
+		t.Fatalf("error returned creating resource: %s\n", err)
+	}
+
+	deletePatch, err := resource.NewDeletePatch(context.TODO(), v1.Service{}, v1.ConfigMap{}, v1.ConfigMap{})
+	if err != nil {
+		t.Fatalf("error returned getting delete patch: %s\n", err)
+	}
+
+	if deletePatch != nil {
+		t.Fatalf("delete patch should be nil, was: %#v", deletePatch)
+	}
+}
+
+// Test_Resource_ConfigMap_ApplyDeleteChange tests the ApplyDeleteChange method.
+func Test_Resource_ConfigMap_ApplyDeleteChange(t *testing.T) {
+	fakeK8sClient := fake.NewSimpleClientset()
+
+	resourceConfig := Config{}
+
+	resourceConfig.K8sClient = fakeK8sClient
+	resourceConfig.Logger = microloggertest.New()
+	resourceConfig.PrometheusReloader = prometheustest.New()
+
+	resourceConfig.CertDirectory = "/certs"
+	resourceConfig.ConfigMapKey = "prometheus.yml"
+	resourceConfig.ConfigMapName = "prometheus"
+	resourceConfig.ConfigMapNamespace = "monitoring"
+
+	resource, err := New(resourceConfig)
+	if err != nil {
+		t.Fatalf("error returned creating resource: %s\n", err)
+	}
+
+	if err := resource.ApplyDeleteChange(context.TODO(), v1.Service{}, v1.ConfigMap{}); err != nil {
+		t.Fatalf("error returned applying delete patch: %s\n", err)
+	}
+}

--- a/service/controller/v1/resource/configmap/update.go
+++ b/service/controller/v1/resource/configmap/update.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/controller/context/finalizerskeptcontext"
 	"github.com/giantswarm/operatorkit/resource/crud"
-	"github.com/giantswarm/prometheus-config-controller/service/controller/v1/prometheus"
 	prometheusclient "github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -86,22 +84,10 @@ func (r *Resource) ApplyUpdateChange(ctx context.Context, obj, updateChange inte
 		}
 	}
 
-	{
-		r.logger.LogCtx(ctx, "level", "debug", "message", "reloading prometheus configuration")
-		// We attempt to reload Prometheus even if the configmap hasn't updated,
-		// as the PrometheusReloader takes care that we don't reload too often.
-		err := r.prometheusReloader.Reload(ctx)
-		if prometheus.IsReloadThrottle(err) {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "did not reload prometheus configuration")
-
-			r.logger.LogCtx(ctx, "level", "debug", "message", err.Error())
-			r.logger.LogCtx(ctx, "level", "debug", "message", "keeping finalizers")
-			finalizerskeptcontext.SetKept(ctx)
-		} else if err != nil {
-			return microerror.Mask(err)
-		} else {
-			r.logger.LogCtx(ctx, "level", "debug", "message", "reloaded prometheus configuration")
-		}
+	// We attempt to reload Prometheus even if the configmap hasn't updated,
+	// as the PrometheusReloader takes care that we don't reload too often.
+	if err := r.prometheusReloader.Reload(ctx); err != nil {
+		return microerror.Mask(err)
 	}
 
 	return nil
@@ -114,7 +100,7 @@ func toConfigMap(v interface{}) (*v1.ConfigMap, error) {
 
 	configMap, ok := v.(*v1.ConfigMap)
 	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", configMap, v)
+		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", v1.ConfigMap{}, v)
 	}
 
 	return configMap, nil


### PR DESCRIPTION
… is removed (#117)"

This reverts commit 60a91957f16940317634a0104245cb1698afeaef.

Reverting https://github.com/giantswarm/prometheus-config-controller/pull/117

We see a lot of issues with configmaps are staggering even if it's deleted. 
Therefore we need to revert this specific PR to give time for a proper fix. 

Slack: https://gigantic.slack.com/archives/C0E0V16DC/p1576056539197400