### PR TITLE
Add node in metrics label

### DIFF
--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -34,6 +34,10 @@ var (
 	// by Prometheus Kubernetes service discovery that holds the target's Kubernetes pod name.
 	KubernetesSDPodNameLabel = model.LabelName("__meta_kubernetes_pod_name")
 
+	// KubernetesSDPodNodeNameLabel is the label applied to the target
+	// by Prometheus Kubernetes service discovery that holds the target's Kubernetes pod node name.
+	KubernetesSDPodNodeNameLabel = model.LabelName("__meta_kubernetes_pod_node_name")
+
 	// KubernetesSDServiceNameLabel is the label applied to the target
 	// by Prometheus Kubernetes service discovery that holds the target's Kubernetes service.
 	KubernetesSDServiceNameLabel = model.LabelName("__meta_kubernetes_service_name")
@@ -122,8 +126,11 @@ var (
 	// MetricPathLabel is the label used to hold the scrape metrics path.
 	MetricPathLabel = "__metrics_path__"
 
-	// NamespaceLabel is the label used to hold the pod name.
+	// PodNameLabel is the label used to hold the pod name.
 	PodNameLabel = "pod_name"
+
+	// Node is the label used to hold the node name.
+	NodeLabel = "node"
 
 	// RoleLabel is the label used to hold the machine's role.
 	RoleLabel = "role"

--- a/service/controller/v1/prometheus/prometheus.go
+++ b/service/controller/v1/prometheus/prometheus.go
@@ -129,7 +129,7 @@ var (
 	// PodNameLabel is the label used to hold the pod name.
 	PodNameLabel = "pod_name"
 
-	// Node is the label used to hold the node name.
+	// NodeLabel is the label used to hold the node name.
 	NodeLabel = "node"
 
 	// RoleLabel is the label used to hold the machine's role.

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -462,12 +462,6 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 			Scheme:                 HttpsScheme,
 			ServiceDiscoveryConfig: endpointSDConfig,
 			RelabelConfigs: []*config.RelabelConfig{
-				// Add Node Label
-				{
-					SourceLabels: model.LabelNames{KubernetesSDNamespaceLabel, KubernetesSDServiceNameLabel},
-					Regex:        ServiceWhitelistRegexp,
-					Action:       config.RelabelKeep,
-				},
 				// Only keep kube-state-metrics targets.
 				{
 					SourceLabels: model.LabelNames{KubernetesSDNamespaceLabel, KubernetesSDServiceNameLabel},

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -462,6 +462,12 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 			Scheme:                 HttpsScheme,
 			ServiceDiscoveryConfig: endpointSDConfig,
 			RelabelConfigs: []*config.RelabelConfig{
+				// Add Node Label
+				{
+					SourceLabels: model.LabelNames{KubernetesSDNamespaceLabel, KubernetesSDServiceNameLabel},
+					Regex:        ServiceWhitelistRegexp,
+					Action:       config.RelabelKeep,
+				},
 				// Only keep kube-state-metrics targets.
 				{
 					SourceLabels: model.LabelNames{KubernetesSDNamespaceLabel, KubernetesSDServiceNameLabel},
@@ -482,6 +488,11 @@ func getScrapeConfigs(service v1.Service, certificateDirectory string) []config.
 				{
 					TargetLabel:  PodNameLabel,
 					SourceLabels: model.LabelNames{KubernetesSDPodNameLabel},
+				},
+				// Add node label.
+				{
+					TargetLabel:  NodeLabel,
+					SourceLabels: model.LabelNames{KubernetesSDPodNodeNameLabel},
 				},
 				// Add cluster_id label.
 				clusterIDLabelRelabelConfig,

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -419,6 +419,10 @@ var (
 				SourceLabels: model.LabelNames{KubernetesSDPodNameLabel},
 			},
 			{
+				TargetLabel:  NodeLabel,
+				SourceLabels: model.LabelNames{KubernetesSDPodNodeNameLabel},
+			},
+			{
 				TargetLabel: ClusterIDLabel,
 				Replacement: "xa5ly",
 			},

--- a/service/controller/v1/prometheus/testdata/scrapeconfig.golden
+++ b/service/controller/v1/prometheus/testdata/scrapeconfig.golden
@@ -263,6 +263,8 @@
     target_label: namespace
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod_name
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
   - target_label: cluster_id
     replacement: xa5ly
   - target_label: cluster_type


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

Related to https://github.com/giantswarm/g8s-prometheus/pull/741

This will add the node label in metrics.
Useful to identify where a specific pod is running. Especially for certificates expiration