### PR TITLE
Relase first version: v0.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,14 +52,21 @@ jobs:
 workflows:
   build:
     jobs:
-      - build
-      - architect/push-to-docker-legacy:
+      - build:
+          filters:
+            tags:
+              only: /.*/
+
+      - architect/push-to-docker:
           name: push-prometheus-config-controller-to-quay
           image: "quay.io/giantswarm/prometheus-config-controller"
           username_envar: "QUAY_USERNAME"
           password_envar: "QUAY_PASSWORD"
           requires:
             - build
+          filters:
+            tags:
+              only: /.*/
 
       - hold-push-prometheus-config-controller-to-aliyun-pr:
           type: approval
@@ -70,7 +77,7 @@ workflows:
             branches:
               ignore: master
 
-      - architect/push-to-docker-legacy:
+      - architect/push-to-docker:
           name: push-prometheus-config-controller-to-aliyun-pr
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/prometheus-config-controller"
           username_envar: "ALIYUN_USERNAME"
@@ -84,7 +91,7 @@ workflows:
               ignore: master
 
       # Push to Aliyun should execute without manual approval on master.
-      - architect/push-to-docker-legacy:
+      - architect/push-to-docker:
           name: push-prometheus-config-controller-to-aliyun-master
           image: "registry-intl.cn-shanghai.aliyuncs.com/giantswarm/prometheus-config-controller"
           username_envar: "ALIYUN_USERNAME"
@@ -95,6 +102,9 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/
+
       - deploy:
           name: deploy
           requires:
@@ -103,3 +113,5 @@ workflows:
           filters:
             branches:
               only: master
+            tags:
+              only: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+
+## [Unreleased]
+
+## [0.1.0] - 2020-07-14
+
+### Added
+
+- This CHANGELOG file
+- Tagging first version
+
+
+
+[Unreleased]: https://github.com/giantswarm/g8s-prometheus/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/g8s-prometheus/tag/v0.1.0


### PR DESCRIPTION
g8s-prometheus currently fails to start due to untagged image which where cleaned up by @giantswarm/team-biscuit.

```
  Normal   BackOff  8m14s (x1253 over 4h52m)  kubelet, ip-10-0-5-97.eu-central-1.compute.internal  Back-off pulling image "quay.io/giantswarm/prometheus-config-controller:0c80a5177c523a75068e9a2c44766bb548013c74"
```

Tagging a first release to fix the issue.