### PR TITLE
Add provider label to static config for etcd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- Add `provider` label to etcd etcdStaticConfig metrics.  
+- Add `provider` label to StaticConfigs for etcd metrics.
 
 ## [1.1.1] - 2020-11-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Added
-
-- Add `provider` label to tenant cluster up metric  
-
 ## [1.1.1] - 2020-11-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Add `provider` label to tenant cluster up metric  
+
 ## [1.1.1] - 2020-11-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Add `provider` label to etcd etcdStaticConfig metrics.  
+
 ## [1.1.1] - 2020-11-16
 
 ### Added

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -931,7 +931,6 @@ func getScrapeConfigs(service v1.Service, metaConfig Config) []config.ScrapeConf
 						Targets: []model.LabelSet{
 							getEtcdTarget(service.Annotations[key.AnnotationEtcdDomain]),
 						},
-						//test
 						Labels: model.LabelSet{
 							model.LabelName(ClusterTypeLabel): model.LabelValue(GuestClusterType),
 							model.LabelName(ClusterIDLabel):   model.LabelValue(clusterID),

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -931,6 +931,7 @@ func getScrapeConfigs(service v1.Service, metaConfig Config) []config.ScrapeConf
 						Targets: []model.LabelSet{
 							getEtcdTarget(service.Annotations[key.AnnotationEtcdDomain]),
 						},
+						//test
 						Labels: model.LabelSet{
 							model.LabelName(ClusterTypeLabel): model.LabelValue(GuestClusterType),
 							model.LabelName(ClusterIDLabel):   model.LabelValue(clusterID),

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -934,6 +934,7 @@ func getScrapeConfigs(service v1.Service, metaConfig Config) []config.ScrapeConf
 						Labels: model.LabelSet{
 							model.LabelName(ClusterTypeLabel): model.LabelValue(GuestClusterType),
 							model.LabelName(ClusterIDLabel):   model.LabelValue(clusterID),
+							model.LabelName(ProviderLabel):   model.LabelValue(provider),
 						},
 					},
 				},

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -935,6 +935,7 @@ func getScrapeConfigs(service v1.Service, metaConfig Config) []config.ScrapeConf
 						Labels: model.LabelSet{
 							model.LabelName(ClusterTypeLabel): model.LabelValue(GuestClusterType),
 							model.LabelName(ClusterIDLabel):   model.LabelValue(clusterID),
+							model.LabelName(ProviderLabel):    model.LabelValue(provider),
 						},
 					},
 				},

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -934,7 +934,6 @@ func getScrapeConfigs(service v1.Service, metaConfig Config) []config.ScrapeConf
 						Labels: model.LabelSet{
 							model.LabelName(ClusterTypeLabel): model.LabelValue(GuestClusterType),
 							model.LabelName(ClusterIDLabel):   model.LabelValue(clusterID),
-							model.LabelName(ProviderLabel):   model.LabelValue(provider),
 						},
 					},
 				},


### PR DESCRIPTION
Update etcdStaticConfig to include the provider label. This is required for the metrics gathered by ` up{cluster_type="guest", instance=~"etcd.*"} `