### PR TITLE
Drop high cardinality IC managed app metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed high cardinality `nginx-ingress-controller` metrics from managed apps job.
+
 ## [1.1.2] - 2020-12-07
 
-## Added
+### Added
 
 - Add `provider` label to StaticConfigs for etcd metrics.
 

--- a/service/controller/v1/prometheus/scrapeconfig.go
+++ b/service/controller/v1/prometheus/scrapeconfig.go
@@ -876,6 +876,12 @@ func getScrapeConfigs(service v1.Service, metaConfig Config) []config.ScrapeConf
 			},
 			MetricRelabelConfigs: []*relabel.Config{
 				providerLabelRelabelConfig,
+				// Drop high cardinality ingress controller metrics.
+				{
+					Action:       ActionDrop,
+					SourceLabels: model.LabelNames{MetricNameLabel},
+					Regex:        relabel.MustNewRegexp(`(nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_bytes_sent_bucket)`),
+				},
 			},
 		},
 

--- a/service/controller/v1/prometheus/scrapeconfig_test_vars.go
+++ b/service/controller/v1/prometheus/scrapeconfig_test_vars.go
@@ -996,6 +996,11 @@ var (
 				TargetLabel: ProviderLabel,
 				Replacement: "aws-test",
 			},
+			{
+				Action:       ActionDrop,
+				SourceLabels: model.LabelNames{MetricNameLabel},
+				Regex:        relabel.MustNewRegexp(`(nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_bytes_sent_bucket)`),
+			},
 		},
 	}
 	TestConfigOneKubeStateManagedApp = config.ScrapeConfig{

--- a/service/controller/v1/prometheus/testdata/scrapeconfig.golden
+++ b/service/controller/v1/prometheus/testdata/scrapeconfig.golden
@@ -440,6 +440,9 @@
   metric_relabel_configs:
   - target_label: provider
     replacement: aws-test
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_bytes_sent_bucket)
+    action: drop
 - job_name: guest-cluster-xa5ly-node-exporter
   honor_timestamps: false
   scheme: http


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/14917

We had metric relabelling to drop high cardinality IC metrics from the ingress job, but this was never replicated in the managed apps job, leading to increased metrics, and therefore memory usage.

This PR drops high cardinality ingress controller metrics from the managed apps job, to reduce overall memory usage

memory usage:
before: ~15gb
after: ~7gb

total metrics:
```
count({__name__=~".+"})
```
before:
```
1563594
```
after:
```
834358
```

total metrics for cluster `pcn01` by job
```
topk(10, sort_desc(count({__name__=~".+", cluster_id="pcn01"}) by (job)))
```
before:
```
{job="guest-cluster-pcn01-managed-app"}	786166
{job="guest-cluster-pcn01-node-exporter"}	118096
{job="guest-cluster-pcn01-kubelet"}	84814
{job="guest-cluster-pcn01-cadvisor"}	65217
{job="guest-cluster-pcn01-workload"}	53147
{job="guest-cluster-pcn01-aws-node"}	13630
{job="guest-cluster-pcn01-calico-node"}	9370
{job="guest-cluster-pcn01-apiserver"}	6711
{job="guest-cluster-pcn01-etcd"}	1252
{job="guest-cluster-pcn01-kube-state-managed-app"}	380
```
after:
```
{job="guest-cluster-pcn01-managed-app"} | 134390
{job="guest-cluster-pcn01-node-exporter"} | 118125
{job="guest-cluster-pcn01-kubelet"} | 84813
{job="guest-cluster-pcn01-cadvisor"} | 65217
{job="guest-cluster-pcn01-workload"} | 53148
{job="guest-cluster-pcn01-aws-node"} | 13630
{job="guest-cluster-pcn01-calico-node"} | 9370
{job="guest-cluster-pcn01-apiserver"} | 6711
{job="guest-cluster-pcn01-etcd"} | 1252
{job="guest-cluster-pcn01-kube-state-managed-app"} | 380
```

total metrics for job `guest-cluster-pcn01-managed-app`
```
topk(10, count by (__name__)({__name__=~".+", job="guest-cluster-pcn01-managed-app"}))
```
before:
```
nginx_ingress_controller_request_duration_seconds_bucket{} | 145308
nginx_ingress_controller_response_size_bucket{} | 145308
nginx_ingress_controller_request_size_bucket{} | 133199
nginx_ingress_controller_response_duration_seconds_bucket{} | 131220
nginx_ingress_controller_bytes_sent_bucket{} | 96872
nginx_ingress_controller_response_size_sum{} | 12109
nginx_ingress_controller_request_size_sum{} | 12109
nginx_ingress_controller_request_size_count{} | 12109
nginx_ingress_controller_request_duration_seconds_sum{} | 12109
nginx_ingress_controller_request_duration_seconds_count{} | 12109
```
after:
```
nginx_ingress_controller_response_size_count{} | 12109
nginx_ingress_controller_request_duration_seconds_count{} | 12109
nginx_ingress_controller_bytes_sent_count{} | 12109
nginx_ingress_controller_request_size_sum{} | 12109
nginx_ingress_controller_request_size_count{} | 12109
nginx_ingress_controller_request_duration_seconds_sum{} | 12109
nginx_ingress_controller_response_size_sum{} | 12109
nginx_ingress_controller_bytes_sent_sum{} | 12109
nginx_ingress_controller_response_duration_seconds_sum{} | 10935
nginx_ingress_controller_response_duration_seconds_count{} | 10935
```

tl;dr:
high cardinality IC metrics, removed, memory go down bigly